### PR TITLE
Cache first channel update

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -34,14 +34,15 @@ import (
 //
 // Currently, only the two-party protocol is fully implemented.
 type Client struct {
-	address     wire.Address
-	conn        clientConn
-	channels    chanRegistry
-	funder      channel.Funder
-	adjudicator channel.Adjudicator
-	wallet      wallet.Wallet
-	pr          persistence.PersistRestorer
-	log         log.Logger // structured logger for this client
+	address       wire.Address
+	conn          clientConn
+	channels      chanRegistry
+	funder        channel.Funder
+	adjudicator   channel.Adjudicator
+	wallet        wallet.Wallet
+	pr            persistence.PersistRestorer
+	log           log.Logger // structured logger for this client
+	version1Cache version1Cache
 
 	sync.Closer
 }

--- a/client/test/alice.go
+++ b/client/test/alice.go
@@ -35,7 +35,7 @@ type Alice struct {
 
 // NewAlice creates a new Proposer that executes the Alice protocol.
 func NewAlice(setup RoleSetup, t *testing.T) *Alice {
-	return &Alice{Proposer: *NewProposer(setup, t, 4)}
+	return &Alice{Proposer: *NewProposer(setup, t, 3)}
 }
 
 // Execute executes the Alice protocol.
@@ -46,8 +46,6 @@ func (r *Alice) Execute(cfg ExecConfig) {
 func (r *Alice) exec(_cfg ExecConfig, ch *paymentChannel) {
 	cfg := _cfg.(*AliceBobExecConfig)
 	we, them := r.Idxs(cfg.Peers())
-	// 1st stage - channel controller set up
-	r.waitStage()
 
 	// 1st Alice receives some updates from Bob
 	for i := 0; i < cfg.NumPayments[them]; i++ {

--- a/client/test/bob.go
+++ b/client/test/bob.go
@@ -26,7 +26,7 @@ type Bob struct {
 
 // NewBob creates a new Responder that executes the Bob protocol.
 func NewBob(setup RoleSetup, t *testing.T) *Bob {
-	return &Bob{Responder: *NewResponder(setup, t, 4)}
+	return &Bob{Responder: *NewResponder(setup, t, 3)}
 }
 
 // Execute executes the Bob protocol.
@@ -37,9 +37,6 @@ func (r *Bob) Execute(cfg ExecConfig) {
 func (r *Bob) exec(_cfg ExecConfig, ch *paymentChannel, propHandler *acceptNextPropHandler) {
 	cfg := _cfg.(*AliceBobExecConfig)
 	we, them := r.Idxs(cfg.Peers())
-
-	// 1st stage - channel controller set up
-	r.waitStage()
 
 	// 1st Bob sends some updates to Alice
 	for i := 0; i < cfg.NumPayments[we]; i++ {

--- a/client/test/proposer.go
+++ b/client/test/proposer.go
@@ -36,6 +36,10 @@ func (r *Proposer) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChannel
 	rng := pkgtest.Prng(r.t, "proposer")
 	assert := assert.New(r.t)
 
+	// ignore proposal handler since Proposer doesn't accept any incoming channels
+	_, wait := r.GoHandle(rng)
+	defer wait()
+
 	prop := r.LedgerChannelProposal(rng, cfg)
 	ch, err := r.ProposeChannel(prop)
 	assert.NoError(err)
@@ -44,10 +48,6 @@ func (r *Proposer) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChannel
 		return
 	}
 	r.log.Infof("New Channel opened: %v", ch.Channel)
-
-	// ignore proposal handler since Proposer doesn't accept any incoming channels
-	_, wait := r.GoHandle(rng)
-	defer wait()
 
 	exec(cfg, ch)
 


### PR DESCRIPTION
When interacting on a channel directly after channel opening, it can happen that the other side has not yet completed the channel opening procedure. In this case, there was a notice about a channel update for an unknown channel and the update would never go through. This change fixes this bug by caching the first channel update until the channel opening is complete.