### PR TITLE
Extend PeerRejectedProposalError for rejected updates

### DIFF
--- a/client/proposal_test.go
+++ b/client/proposal_test.go
@@ -30,19 +30,21 @@ func TestProposalResponder_Accept_Nil(t *testing.T) {
 
 func TestPeerRejectedProposalError(t *testing.T) {
 	reason := "some-random-reason"
-	var err error = errors.WithStack(PeerRejectedProposalError{reason})
+	var err error = newPeerRejectedError("update", reason)
 	t.Run("direct_error", func(t *testing.T) {
-		peerRejectedProposalError := PeerRejectedProposalError{}
+		peerRejectedProposalError := PeerRejectedError{}
 		gotPeerRejectedError := errors.As(err, &peerRejectedProposalError)
 		require.True(t, gotPeerRejectedError)
-		assert.Equal(t, reason, peerRejectedProposalError.reason)
+		assert.Equal(t, reason, peerRejectedProposalError.Reason)
+		assert.Contains(t, err.Error(), reason)
 	})
 
 	t.Run("wrapped_error", func(t *testing.T) {
 		wrappedError := errors.WithMessage(err, "some higher level error")
-		peerRejectedError := PeerRejectedProposalError{}
+		peerRejectedError := PeerRejectedError{}
 		gotPeerRejectedError := errors.As(wrappedError, &peerRejectedError)
 		require.True(t, gotPeerRejectedError)
-		assert.Equal(t, reason, peerRejectedError.reason)
+		assert.Equal(t, reason, peerRejectedError.Reason)
+		assert.Contains(t, err.Error(), reason)
 	})
 }

--- a/client/update.go
+++ b/client/update.go
@@ -200,7 +200,7 @@ func (c *Channel) update(ctx context.Context, next *channel.State) (err error) {
 	c.Log().Tracef("Received update response (%T): %v", res, res)
 
 	if rej, ok := res.(*msgChannelUpdateRej); ok {
-		return errors.Errorf("update rejected: %s", rej.Reason)
+		return newPeerRejectedError("channel update", rej.Reason)
 	}
 
 	acc := res.(*msgChannelUpdateAcc) // safe by predicate of the updateResRecv


### PR DESCRIPTION
I have renamed `PeerRejectedProposalError` to `PeerRejectedError`, so that the same error type can be used when peer rejects an update as well.

The other option could be to use two error types. Request your feedback on this.