### PR TITLE
Add current State to HandleUpdate.

### DIFF
--- a/client/channel.go
+++ b/client/channel.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2021 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -139,6 +139,7 @@ func (c *Channel) Params() *channel.Params {
 
 // State returns the current state.
 // Clone it if you want to modify it.
+// Can not be called from an update handler.
 func (c *Channel) State() *channel.State {
 	c.machMtx.Lock()
 	defer c.machMtx.Unlock()
@@ -147,6 +148,7 @@ func (c *Channel) State() *channel.State {
 }
 
 // Phase returns the current phase of the channel state machine.
+// Can not be called from an update handler.
 func (c *Channel) Phase() channel.Phase {
 	c.machMtx.Lock()
 	defer c.machMtx.Unlock()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2021 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ func TestClient_Handle_NilArgs(t *testing.T) {
 	c, err := New(wtest.NewRandomAddress(rng), &DummyBus{t}, &DummyFunder{t}, &DummyAdjudicator{t}, wtest.RandomWallet())
 	require.NoError(t, err)
 
-	dummyUH := UpdateHandlerFunc(func(ChannelUpdate, *UpdateResponder) {})
+	dummyUH := UpdateHandlerFunc(func(*channel.State, ChannelUpdate, *UpdateResponder) {})
 	assert.Panics(t, func() { c.Handle(nil, dummyUH) })
 	dummyPH := ProposalHandlerFunc(func(ChannelProposal, *ProposalResponder) {})
 	assert.Panics(t, func() { c.Handle(dummyPH, nil) })

--- a/client/test/role.go
+++ b/client/test/role.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2021 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -422,7 +422,7 @@ type roleUpdateHandler role
 func (r *role) UpdateHandler() *roleUpdateHandler { return (*roleUpdateHandler)(r) }
 
 // HandleUpdate implements the Role as its own UpdateHandler.
-func (h *roleUpdateHandler) HandleUpdate(up client.ChannelUpdate, res *client.UpdateResponder) {
+func (h *roleUpdateHandler) HandleUpdate(_ *channel.State, up client.ChannelUpdate, res *client.UpdateResponder) {
 	ch, ok := h.chans.get(up.State.ID)
 	if !ok {
 		h.t.Errorf("unknown channel: %v", up.State.ID)


### PR DESCRIPTION
Since Channel.State() can not be called from an Update handler and
having the current state in the ChannelUpdate does not make sense,
i moved added it as argument to HandleUpate.

Closes #15 