### PR TITLE
:bug: [client] Fix NewRandomLedgerChannelProposal

### DIFF
--- a/client/proposal_internal_test.go
+++ b/client/proposal_internal_test.go
@@ -124,7 +124,7 @@ func NewRandomBaseChannelProposal(rng *rand.Rand, opts ...channeltest.RandomOpt)
 func NewRandomLedgerChannelProposal(rng *rand.Rand, opts ...channeltest.RandomOpt) *LedgerChannelProposal {
 	opt := make(channeltest.RandomOpt).Append(opts...)
 	base := NewRandomBaseChannelProposal(rng, opt)
-	peers := wiretest.NewRandomAddresses(rng, opt.NumParts(rng))
+	peers := wiretest.NewRandomAddresses(rng, base.NumPeers())
 	return &LedgerChannelProposal{
 		BaseChannelProposal: base,
 		Participant:         wallettest.NewRandomAddress(rng),


### PR DESCRIPTION
An inconsistent LedgerChannelProposal may have been generated because
the allocation was generated independent of the number of participants.

Signed-off-by: Matthias Geihs <matthias@perun.network>