### PR TITLE
:bug: [channel/machine, client] Sub-channel withdrawal without regist…

### DIFF
--- a/channel/machine.go
+++ b/channel/machine.go
@@ -400,10 +400,10 @@ func (m *machine) SetProgressed(e *ProgressedEvent) error {
 
 // SetWithdrawing sets the state machine to the Withdrawing phase. The current
 // state was registered on-chain and funds withdrawal is in progress.
-// This phase can only be reached from phase Acting, Registered, Progressed, or
+// This phase can only be reached from phase Final, Registered, Progressed, or
 // Withdrawing.
 func (m *machine) SetWithdrawing() error {
-	if !inPhase(m.phase, []Phase{Acting, Registered, Progressed, Withdrawing}) {
+	if !inPhase(m.phase, []Phase{Final, Registered, Progressed, Withdrawing}) {
 		return m.phaseErrorf(m.selfTransition(), "can only withdraw after registering")
 	}
 	m.setPhase(Withdrawing)

--- a/client/test/channel.go
+++ b/client/test/channel.go
@@ -184,7 +184,9 @@ func (ch *paymentChannel) settleImpl(secondary bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), ch.r.timeout)
 	defer cancel()
 
-	assert.NoError(ch.Register(ctx))
+	if ch.IsLedgerChannel() || !ch.State().IsFinal {
+		assert.NoError(ch.Register(ctx))
+	}
 
 	assert.NoError(ch.Settle(ctx, secondary))
 	ch.assertBals(ch.State())


### PR DESCRIPTION
…ering

The current implementation required a sub-channel to be registered on-chain before it could be withdrawn.
However, in the optimistic case, a sub-channel should be withdrawable into its parent channel without
blockchain interaction. We achieve this by modifying the state machine to allow for a transition from
phase final to phase withdrawing.

Signed-off-by: Matthias Geihs <matthias@perun.network>

Closes #58 