### PR TITLE
Enable logging per default

### DIFF
--- a/client/init.go
+++ b/client/init.go
@@ -1,0 +1,25 @@
+// Copyright 2021 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/sirupsen/logrus"
+
+	plogrus "perun.network/go-perun/log/logrus"
+)
+
+func init() {
+	plogrus.Set(logrus.WarnLevel, &logrus.TextFormatter{})
+}


### PR DESCRIPTION
Enable default logging with level 'Warning' to increase usability.
Closes #64