### PR TITLE
:boom: [channel] Update NewFundingTimeoutError to return a value

### DIFF
--- a/backend/ethereum/channel/funder_test.go
+++ b/backend/ethereum/channel/funder_test.go
@@ -251,7 +251,7 @@ func testFundingTimeout(t *testing.T, faultyPeer, n int) {
 			err := funder.Fund(ctx, *req)
 			require.Error(t, err)
 			require.True(rt, channel.IsFundingTimeoutError(err), "funder should return FundingTimeoutError")
-			pErr := errors.Cause(err).(*channel.FundingTimeoutError) // unwrap error
+			pErr := errors.Cause(err).(channel.FundingTimeoutError) // unwrap error
 			// Check that `faultyPeer` is reported as faulty.
 			require.Len(t, pErr.Errors, len(alloc.Assets))
 			for _, e := range pErr.Errors {

--- a/channel/funder.go
+++ b/channel/funder.go
@@ -73,7 +73,7 @@ func NewFundingTimeoutError(fundingErrs []*AssetFundingError) error {
 	if len(fundingErrs) == 0 {
 		return nil
 	}
-	return errors.WithStack(&FundingTimeoutError{fundingErrs})
+	return errors.WithStack(FundingTimeoutError{fundingErrs})
 }
 
 func (e FundingTimeoutError) Error() string {
@@ -86,7 +86,7 @@ func (e FundingTimeoutError) Error() string {
 
 // IsFundingTimeoutError checks whether an error is a FundingTimeoutError.
 func IsFundingTimeoutError(err error) bool {
-	_, ok := errors.Cause(err).(*FundingTimeoutError)
+	_, ok := errors.Cause(err).(FundingTimeoutError)
 	return ok
 }
 

--- a/channel/funder_test.go
+++ b/channel/funder_test.go
@@ -47,7 +47,7 @@ func TestFundingTimeoutError(t *testing.T) {
 		{7531, []Index{1, 3}},
 	}
 	err := NewFundingTimeoutError(errs)
-	perr, ok := errors.Cause(err).(*FundingTimeoutError)
+	perr, ok := errors.Cause(err).(FundingTimeoutError)
 	require.True(t, ok)
 	assert.True(IsFundingTimeoutError(err))
 	assert.True(IsFundingTimeoutError(perr))


### PR DESCRIPTION
- Previously, the function returned pointer to an error. Update it to
  return a value.

- It is idiomatic to return error types as values. The change also
  ensures this func is consistent with constructors for other error
  types.

Closes #73.

Signed-off-by: Manoranjith <ponraj.manoranjitha@in.bosch.com>