### PR TITLE
[backend/eth/channel] Fix BlockTimeout test.

### DIFF
--- a/backend/ethereum/channel/timeout_test.go
+++ b/backend/ethereum/channel/timeout_test.go
@@ -73,6 +73,8 @@ func TestBlockTimeout_Wait(t *testing.T) {
 			wait <- bt.Wait(ctx)
 		}()
 
+		// Wait for the go-routine above to start.
+		time.Sleep(100 * time.Millisecond)
 		for i := 0; i < numBlocks; i++ {
 			select {
 			case err := <-wait:


### PR DESCRIPTION
Make the `TestBlockTimeout_Wait/normalWait` stable for CI.  
Example failure: https://github.com/hyperledger-labs/go-perun/runs/2692568029?check_suite_focus=true#step:4:89