### PR TITLE
Log message type.

### DIFF
--- a/client/channelconn.go
+++ b/client/channelconn.go
@@ -99,7 +99,7 @@ func (c *channelConn) Send(ctx context.Context, msg wire.Msg) error {
 		if channel.Index(i) == c.idx {
 			continue // skip own peer
 		}
-		c.log.WithField("peer", peer).Debugf("channelConn: publishing message: %v", msg)
+		c.log.WithField("peer", peer).Debugf("channelConn: publishing message: %v: %+v", msg.Type(), msg)
 		env := &wire.Envelope{
 			Sender:    c.sender(),
 			Recipient: peer,

--- a/client/clientconn.go
+++ b/client/clientconn.go
@@ -74,7 +74,7 @@ func (c clientConn) nextReq(ctx context.Context) (*wire.Envelope, error) {
 // pubMsg publishes the given message on the wire bus, setting the own client as
 // the sender.
 func (c *clientConn) pubMsg(ctx context.Context, msg wire.Msg, rec wire.Address) error {
-	c.Log().WithField("peer", rec).Debugf("Publishing message: %v", msg)
+	c.Log().WithField("peer", rec).Debugf("Publishing message: %v: %+v", msg.Type(), msg)
 	return c.bus.Publish(ctx, &wire.Envelope{
 		Sender:    c.sender,
 		Recipient: rec,


### PR DESCRIPTION
Log the message type instead of a binary blob.

Closes #95 