### PR TITLE
:boom: [backend/eth/channel] Remove validation of adj in validateAssettHolder

### DIFF
--- a/backend/ethereum/channel/asset.go
+++ b/backend/ethereum/channel/asset.go
@@ -36,22 +36,28 @@ type Asset = wallet.Address
 
 var _ channel.Asset = new(Asset)
 
-// ValidateAssetHolderETH checks if the bytecodes at the given addresses are
-// correct and if the adjudicator address is correctly set in the asset holder
-// contract. Returns a ContractBytecodeError if the bytecode at the given
-// address is invalid. This error can be checked with function
-// IsErrInvalidContractCode.
+// ValidateAssetHolderETH checks if the bytecode at the given asset holder ETH
+// address is correct and if the adjudicator address is correctly set in the
+// asset holder contract. The contract code at the adjudicator address is not
+// validated, it is the user's responsibility to provide a valid adjudicator
+// address.
+//
+// Returns a ContractBytecodeError if the bytecode is invalid. This error can
+// be checked with function IsErrInvalidContractCode.
 func ValidateAssetHolderETH(ctx context.Context,
 	backend bind.ContractBackend, assetHolderETH, adjudicator common.Address) error {
 	return validateAssetHolder(ctx, backend, assetHolderETH, adjudicator,
 		assetholdereth.AssetHolderETHBinRuntime)
 }
 
-// ValidateAssetHolderERC20 checks if the bytecodes at the given addresses are
-// correct and if the adjudicator address is correctly set in the asset holder
-// contract. Returns a ContractBytecodeError if the bytecode at the given
-// address is invalid. This error can be checked with function
-// IsErrInvalidContractCode.
+// ValidateAssetHolderERC20 checks if the bytecode at the given asset holder
+// ERC20 address is correct and if the adjudicator address is correctly set in
+// the asset holder contract. The contract code at the adjudicator address is
+// not validated, it is the user's responsibility to provide a valid
+// adjudicator address.
+//
+// Returns a ContractBytecodeError if the bytecode is invalid. This error can
+// be checked with function IsErrInvalidContractCode.
 func ValidateAssetHolderERC20(ctx context.Context,
 	backend bind.ContractBackend, assetHolderERC20, adjudicator, token common.Address) error {
 	return validateAssetHolder(ctx, backend, assetHolderERC20, adjudicator,
@@ -79,8 +85,7 @@ func validateAssetHolder(ctx context.Context,
 		return errors.Wrap(ErrInvalidContractCode, "incorrect adjudicator code")
 	}
 
-	return errors.WithMessage(ValidateAdjudicator(ctx, backend, adjudicatorAddr),
-		"validating Adjudicator")
+	return nil
 }
 
 func validateContract(ctx context.Context,

--- a/backend/ethereum/channel/asset_test.go
+++ b/backend/ethereum/channel/asset_test.go
@@ -86,6 +86,13 @@ func testValidateAssetHolder(t *testing.T,
 		require.True(t, ethchannel.IsErrInvalidContractCode(validator(ctx, s.CB, assetHolderAddr, adjAddrToExpect)))
 	})
 
+	t.Run("correct_adj_addr_with_invalid_contract", func(t *testing.T) {
+		adjudicatorAddr := (common.Address)(ethwallettest.NewRandomAddress(rng))
+		assetHolderAddr, err := deployer(ctx, *s.CB, adjudicatorAddr, s.TxSender.Account)
+		require.NoError(t, err)
+		require.NoError(t, validator(ctx, s.CB, assetHolderAddr, adjudicatorAddr))
+	})
+
 	t.Run("all_correct", func(t *testing.T) {
 		adjudicatorAddr, err := ethchannel.DeployAdjudicator(ctx, *s.CB, s.TxSender.Account)
 		require.NoError(t, err)


### PR DESCRIPTION
- Contract code at adjudicator address is not validated because, the
  it is passed by the caller, hence it is the responsibility of the
  caller to provide a valid address.

Resolves #109.