### PR TITLE
Resistant event subs

### DIFF
--- a/backend/ethereum/subscription/resistanteventsub.go
+++ b/backend/ethereum/subscription/resistanteventsub.go
@@ -1,0 +1,232 @@
+// Copyright 2021 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscription
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
+
+	cherrors "perun.network/go-perun/backend/ethereum/channel/errors"
+	"perun.network/go-perun/log"
+	pkgsync "perun.network/go-perun/pkg/sync"
+)
+
+type (
+	// ResistantEventSub wraps an `EventSub` and makes it resistant to chain reorgs.
+	// It handles `removed` and `rebirth` events and has a `finalityDepth`
+	// threshold to decide when an Event is final.
+	// It will never emit the same event twice.
+	ResistantEventSub struct {
+		closer        pkgsync.Closer
+		sub           *EventSub
+		finalityDepth *big.Int
+
+		lastBlockNum *big.Int
+		heads        chan *types.Header
+		headSub      ethereum.Subscription
+		events       map[common.Hash]*Event
+	}
+)
+
+// NewResistantEventSub creates a new `ResistantEventSub` from the given
+// `EventSub`. Closes the passed `EventSub` when done.
+// `finalityDepth` defines in how many blocks an event needs to be included.
+// `finalityDepth` cannot be smaller than 1.
+// The passed `EventSub` should query more than `finalityDepth` blocks into
+// the past.
+func NewResistantEventSub(ctx context.Context, sub *EventSub, cr ethereum.ChainReader, finalityDepth uint64) (*ResistantEventSub, error) {
+	if finalityDepth < 1 {
+		panic("finalityDepth needs to be at least 1")
+	}
+	last, err := cr.HeaderByNumber(ctx, nil)
+	if err != nil {
+		err = cherrors.CheckIsChainNotReachableError(err)
+		return nil, errors.WithMessage(err, "subscribing to headers")
+	}
+	log.Debugf("Resistant Event sub started at block: %v", last.Number)
+	// Use a large buffer to not block geth.
+	heads := make(chan *types.Header, 128)
+	headSub, err := cr.SubscribeNewHead(ctx, heads)
+	if err != nil {
+		headSub.Unsubscribe()
+		err = cherrors.CheckIsChainNotReachableError(err)
+		return nil, errors.WithMessage(err, "subscribing to headers")
+	}
+
+	fd := new(big.Int)
+	fd.SetUint64(finalityDepth)
+	ret := &ResistantEventSub{
+		sub:           sub,
+		lastBlockNum:  last.Number,
+		heads:         heads,
+		headSub:       headSub,
+		finalityDepth: fd,
+		events:        make(map[common.Hash]*Event),
+	}
+	ret.closer.OnCloseAlways(func() {
+		headSub.Unsubscribe()
+		sub.Close()
+	})
+	return ret, nil
+}
+
+// Read reads all past and future events into `sink`.
+// Can be aborted by cancelling `ctx` or `Close()`.
+// All events can be considered final.
+func (s *ResistantEventSub) Read(_ctx context.Context, sink chan<- *Event) error {
+	ctx, cancel := context.WithCancel(_ctx)
+	defer cancel()
+	subErr := make(chan error, 1)
+	rawEvents := make(chan *Event, 128)
+	// Read events from the underlying event subscription.
+	go func() {
+		subErr <- s.sub.Read(ctx, rawEvents)
+	}()
+
+	for {
+		select {
+		case head := <-s.heads:
+			if head == nil {
+				return errors.New("head sub returned nil")
+			}
+			s.processHead(head, sink)
+		case event := <-rawEvents:
+			s.processEvent(event, sink)
+		case e := <-s.headSub.Err():
+			return errors.WithMessage(e, "underlying head subscription")
+		case e := <-subErr:
+			if e != nil {
+				return errors.WithMessage(e, "underlying EventSub.Read")
+			}
+			return errors.New("underlying event sub terminated")
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.closer.Closed():
+			return nil
+		}
+	}
+}
+
+// ReadPast reads all past events into `sink`.
+// Can be aborted by cancelling `ctx` or `Close()`.
+// All events can be considered final.
+func (s *ResistantEventSub) ReadPast(_ctx context.Context, sink chan<- *Event) error {
+	ctx, cancel := context.WithCancel(_ctx)
+	defer cancel()
+	subErr := make(chan error, 1)
+	rawEvents := make(chan *Event, 128)
+	// Read events from the underlying event subscription.
+	go func() {
+		defer close(rawEvents)
+		subErr <- s.sub.ReadPast(ctx, rawEvents)
+	}()
+
+	for {
+		select {
+		case head := <-s.heads:
+			if head == nil {
+				return errors.New("head sub returned nil")
+			}
+			s.processHead(head, sink)
+		case event := <-rawEvents:
+			if event == nil {
+				return nil
+			}
+			s.processEvent(event, sink)
+		case e := <-s.headSub.Err():
+			return errors.WithMessage(e, "underlying head subscription")
+		case e := <-subErr:
+			if e != nil {
+				return errors.WithMessage(e, "underlying EventSub.Read")
+			}
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.closer.Closed():
+			return nil
+		}
+	}
+}
+
+// handles events that are received from the geth node and checks if they
+// are final.
+func (s *ResistantEventSub) processEvent(event *Event, sink chan<- *Event) {
+	hash := event.Log.TxHash
+	log := log.WithField("hash", hash.Hex())
+
+	if event.Log.Removed { // nolint: nestif
+		if _, found := s.events[hash]; !found {
+			log.Error("Race detected between event and header sub")
+		} else {
+			log.Trace("Event preliminary excluded")
+			delete(s.events, hash)
+		}
+	} else {
+		if s.isFinal(event) {
+			sink <- event
+			delete(s.events, hash)
+		} else {
+			log.Trace("Event preliminary included")
+			s.events[hash] = event
+		}
+	}
+}
+
+// handles headers that are received from the geth node and checks if events
+// become final.
+func (s *ResistantEventSub) processHead(head *types.Header, sink chan<- *Event) {
+	log.Tracef("Received new block. From %v to %v", s.lastBlockNum, head.Number)
+	s.lastBlockNum.Set(head.Number)
+
+	for _, event := range s.events {
+		if s.isFinal(event) {
+			sink <- event
+			delete(s.events, event.Log.TxHash)
+		}
+	}
+}
+
+func (s *ResistantEventSub) isFinal(event *Event) bool {
+	log := log.WithField("hash", event.Log.TxHash.Hex())
+	diff := new(big.Int).Sub(s.lastBlockNum, big.NewInt(int64(event.Log.BlockNumber)))
+
+	if diff.Sign() < 0 {
+		log.Tracef("Event sub was faster than head sub, ignored")
+		return false
+	} else {
+		included := new(big.Int).Add(diff, big.NewInt(1))
+		if included.Cmp(s.finalityDepth) >= 0 {
+			log.Debugf("Event final after %d block(s)", included)
+			return true
+		} else {
+			log.Tracef("Event included %d time(s)", included)
+			return false
+		}
+	}
+}
+
+// Close closes the sub and the underlying `EventSub`.
+// Can be called more than once. Is thread safe.
+func (s *ResistantEventSub) Close() {
+	if err := s.closer.Close(); err != nil && !pkgsync.IsAlreadyClosedError(err) {
+		log.WithError(err).Error("could not close EventSub")
+	}
+	// NOTE: The underlying `EventSub` is closed in the `OnCloseAlways` hook.
+}

--- a/backend/ethereum/subscription/resistanteventsub_test.go
+++ b/backend/ethereum/subscription/resistanteventsub_test.go
@@ -1,0 +1,228 @@
+// Copyright 2021 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscription_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"perun.network/go-perun/backend/ethereum/bindings/peruntoken"
+	"perun.network/go-perun/backend/ethereum/channel/test"
+	"perun.network/go-perun/backend/ethereum/subscription"
+	"perun.network/go-perun/log"
+	pctx "perun.network/go-perun/pkg/context"
+	pkgtest "perun.network/go-perun/pkg/test"
+)
+
+var event = func() *subscription.Event {
+	return &subscription.Event{
+		Name: "Approval",
+		Data: new(peruntoken.PerunTokenApproval),
+	}
+}
+
+// Defines a soft maximum value for the finality that tests will use.
+// Must be divisible by 2 and greater than 1.
+const maxFinality = 20
+
+// TestResistantEventSub_Confirm tests that a TX is confirmed exactly
+// after being included in `finalityDepth` many blocks.
+func TestResistantEventSub_Confirm(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	rng := pkgtest.Prng(t)
+	require := require.New(t)
+	s := test.NewTokenSetup(ctx, t, rng)
+
+	finality := rng.Int31n(maxFinality) + 1
+	sub, err := subscription.Subscribe(ctx, s.CB, s.Contract, event, 0, uint64(finality))
+	require.NoError(err)
+	defer sub.Close()
+
+	// Send and Confirm the TX. The simulated backend already mined a block here,
+	// so the TX has 1 confirmation now.
+	s.ConfirmTx(s.IncAllowance(ctx), true)
+	// Wait `finality-1` blocks.
+	for j := int32(0); j < finality-1; j++ {
+		NoEvent(require, sub)
+		s.SB.Commit()
+	}
+	OneEvent(require, sub)
+}
+
+// TestResistantEventSub_ReadPast tests that `ReadPast` only returns events
+// that were first emitted before the sub was created even when they finalize
+// after its creation.
+func TestResistantEventSub_ReadPast(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	rng := pkgtest.Prng(t)
+	require := require.New(t)
+	s := test.NewTokenSetup(ctx, t, rng)
+	numTx := 5
+	finality := int(rng.Int31n(maxFinality) + 1)
+
+	// Send some past tx.
+	for i := 0; i < numTx; i++ {
+		s.IncAllowance(ctx)
+	}
+
+	// Create a sub to go `numTx+finality` into the past.
+	sub, err := subscription.Subscribe(ctx, s.CB, s.Contract, event, uint64(numTx), uint64(finality))
+	require.NoError(err)
+	defer sub.Close()
+
+	// Finalize the past events by mining blocks.
+	for i := 0; i < finality-1; i++ {
+		s.SB.Commit()
+	}
+	// Send some future tx.
+	for i := 0; i < numTx; i++ {
+		s.IncAllowance(ctx)
+	}
+	// Finalize the future events by mining blocks.
+	for i := 0; i < finality-1; i++ {
+		s.SB.Commit()
+	}
+
+	// Receive exactly `numTx` past events.
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		sink := make(chan *subscription.Event, numTx+1)
+		err := sub.ReadPast(ctx, sink) // read only past events
+		require.NoError(err)
+
+		for i := 0; i < numTx; i++ {
+			require.NotNil(<-sink)
+		}
+
+		select {
+		case event := <-sink:
+			require.Nil(event)
+		default:
+		}
+	}
+}
+
+// TestResistantEventSub_ReorgConfirm tests that a TX is confirmed exactly
+// after `finalityDepth` blocks even when reorgs occur.
+func TestResistantEventSub_ReorgConfirm(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	rng := pkgtest.Prng(t)
+	require := require.New(t)
+	s := test.NewTokenSetup(ctx, t, rng)
+
+	finality := rng.Int31n(maxFinality-2) + 2
+	sub, err := subscription.Subscribe(ctx, s.CB, s.Contract, event, 0, uint64(finality))
+	require.NoError(err)
+	defer sub.Close()
+
+	// Allow the reorg to go up to `maxFinality` blocks into the past.
+	for i := 0; i < maxFinality; i++ {
+		s.SB.Commit()
+	}
+
+	// Send and Confirm the TX
+	s.IncAllowance(ctx)
+	// Reorg until the block hight hits `finality` blocks.
+	for h := int64(0); h < int64(finality-1); {
+		d := rng.Int63n(maxFinality/2-1) + 1
+		l := rng.Int63n(maxFinality/2-1) + 1
+		NoEvent(require, sub)
+		log.Debugf("[h=%d] Reorg with depth: %d, length: %d", h, d, l)
+		s.SB.Reorg(ctx, uint64(d), func(txs []types.Transactions) []types.Transactions {
+			return append(txs, make([]types.Transactions, int(d+l)-len(txs))...)
+		})
+		h += l
+	}
+	// Verify that the event arrived.
+	OneEvent(require, sub)
+}
+
+// TestResistantEventSub_ReorgRemove tests that a TX is never confirmed if it
+// was removed by a reorg.
+func TestResistantEventSub_ReorgRemove(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	rng := pkgtest.Prng(t)
+	require := require.New(t)
+	s := test.NewTokenSetup(ctx, t, rng)
+
+	finality := rng.Int31n(maxFinality-2) + 2
+	sub, err := subscription.Subscribe(ctx, s.CB, s.Contract, event, 0, uint64(finality))
+	require.NoError(err)
+	defer sub.Close()
+
+	// Send and Confirm the TX
+	s.IncAllowance(ctx)
+	NoEvent(require, sub)
+
+	// Go back one block and remove the TX with a reorg.
+	s.SB.Reorg(ctx, 1, func(txs []types.Transactions) []types.Transactions {
+		return make([]types.Transactions, 2)
+	})
+
+	NoEvent(require, sub)
+	// Verify that the event never arrives.
+	for i := 0; i < maxFinality; i++ {
+		s.SB.Commit()
+	}
+	time.Sleep(1 * time.Second) // give the event subscription time to catch up
+	NoEvent(require, sub)
+}
+
+// TestResistantEventSub_New checks that `NewResistantEventSub` panics for
+// `finalityDepth` < 1.
+func TestResistantEventSub_New(t *testing.T) {
+	require.PanicsWithValue(t, "finalityDepth needs to be at least 1", func() {
+		subscription.NewResistantEventSub(context.Background(), nil, nil, 0)
+	})
+}
+
+// NoEvent checks that no event can be read from `sub`.
+func NoEvent(require *require.Assertions, sub *subscription.ResistantEventSub) {
+	nEvents(require, 0, sub)
+}
+
+// OneEvent checks that exactly one event can be read from `sub`.
+func OneEvent(require *require.Assertions, sub *subscription.ResistantEventSub) {
+	nEvents(require, 1, sub)
+}
+
+// nEvents checks that exactly `n` events can be read from `sub`.
+func nEvents(require *require.Assertions, n int, sub *subscription.ResistantEventSub) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	sink := make(chan *subscription.Event, n+1)
+
+	err := sub.Read(ctx, sink)
+	require.True(pctx.IsContextError(err))
+
+	for i := 0; i < n; i++ {
+		require.NotNil(<-sink)
+	}
+
+	select {
+	case event := <-sink:
+		require.Nil(event)
+	default:
+	}
+}


### PR DESCRIPTION
Adds the `ResistantEventSub` type.  
Also introduced a convenience function `Subscribe(ctx context.Context, cr ethereum.ChainReader, contract *bind.BoundContract, eFact EventFactory, startBlockOffset, confirmations uint64) (*ResistantEventSub, error)` which makes it easier to create a resistant sub.  
I am not happy with the arguments of `Subscribe` yet, since it are so many.

Closes #40 
Draft until #105 is closed