### PR TITLE
Integrate Resistant Event Subs

### DIFF
--- a/backend/ethereum/channel/conclude.go
+++ b/backend/ethereum/channel/conclude.go
@@ -59,10 +59,11 @@ func (a *Adjudicator) ensureConcluded(ctx context.Context, req channel.Adjudicat
 	}()
 
 	// In final Register calls, as the non-initiator, we optimistically wait for
-	// the other party to send the transaction first for secondaryWaitBlocks many
-	// blocks.
+	// the other party to send the transaction first for
+	// `secondaryWaitBlocks + TxFinalityDepth` many blocks.
 	if req.Tx.IsFinal && req.Secondary {
-		isConcluded, err := waitConcludedForNBlocks(waitCtx, a, events, secondaryWaitBlocks)
+		waitBlocks := secondaryWaitBlocks + int(TxFinalityDepth)
+		isConcluded, err := waitConcludedForNBlocks(waitCtx, a, events, waitBlocks)
 		if err != nil {
 			return err
 		} else if isConcluded {

--- a/backend/ethereum/channel/conclude.go
+++ b/backend/ethereum/channel/conclude.go
@@ -38,7 +38,7 @@ const secondaryWaitBlocks = 2
 //   - if none found, conclude/concludeFinal is called on the adjudicator
 // - it waits for a Concluded event from the blockchain.
 func (a *Adjudicator) ensureConcluded(ctx context.Context, req channel.AdjudicatorReq, subStates channel.StateMap) error {
-	sub, err := subscription.NewEventSub(ctx, a.ContractBackend, a.bound, updateEventType(req.Params.ID()), startBlockOffset)
+	sub, err := subscription.Subscribe(ctx, a.ContractBackend, a.bound, updateEventType(req.Params.ID()), startBlockOffset, TxFinalityDepth)
 	if err != nil {
 		return errors.WithMessage(err, "subscribing")
 	}
@@ -116,7 +116,7 @@ func (a *Adjudicator) conclude(ctx context.Context, req channel.AdjudicatorReq, 
 }
 
 // isConcluded returns whether a channel is already concluded.
-func (a *Adjudicator) isConcluded(ctx context.Context, sub *subscription.EventSub) (bool, error) {
+func (a *Adjudicator) isConcluded(ctx context.Context, sub *subscription.ResistantEventSub) (bool, error) {
 	events := make(chan *subscription.Event, 10)
 	subErr := make(chan error, 1)
 	// Write the events into events.

--- a/backend/ethereum/channel/funder.go
+++ b/backend/ethereum/channel/funder.go
@@ -263,7 +263,7 @@ func (f *Funder) checkFunded(ctx context.Context, amount *big.Int, asset assetHo
 	return left.Sign() != 1, errors.WithMessagef(<-subErr, "filtering old Funding events for asset %d", asset.assetIndex)
 }
 
-func (f *Funder) depositedSub(ctx context.Context, contract *bind.BoundContract, fundingIDs ...[32]byte) (*subscription.EventSub, error) {
+func (f *Funder) depositedSub(ctx context.Context, contract *bind.BoundContract, fundingIDs ...[32]byte) (*subscription.ResistantEventSub, error) {
 	filter := make([]interface{}, len(fundingIDs))
 	for i, fundingID := range fundingIDs {
 		filter[i] = fundingID
@@ -275,7 +275,7 @@ func (f *Funder) depositedSub(ctx context.Context, contract *bind.BoundContract,
 			Filter: [][]interface{}{filter},
 		}
 	}
-	sub, err := subscription.NewEventSub(ctx, f, contract, event, startBlockOffset)
+	sub, err := subscription.Subscribe(ctx, f, contract, event, startBlockOffset, TxFinalityDepth)
 	return sub, errors.WithMessage(err, "subscribing to deposited event")
 }
 

--- a/backend/ethereum/channel/subscription.go
+++ b/backend/ethereum/channel/subscription.go
@@ -44,7 +44,7 @@ func (a *Adjudicator) Subscribe(ctx context.Context, params *channel.Params) (ch
 			Filter: [][]interface{}{{params.ID()}},
 		}
 	}
-	sub, err := subscription.NewEventSub(ctx, a.ContractBackend, a.bound, eFact, startBlockOffset)
+	sub, err := subscription.Subscribe(ctx, a.ContractBackend, a.bound, eFact, startBlockOffset, TxFinalityDepth)
 	if err != nil {
 		return nil, errors.WithMessage(err, "creating filter-watch event subscription")
 	}
@@ -66,8 +66,8 @@ func (a *Adjudicator) Subscribe(ctx context.Context, params *channel.Params) (ch
 
 // RegisteredSub implements the channel.AdjudicatorSubscription interface.
 type RegisteredSub struct {
-	cr     ethereum.ChainReader   // chain reader to read block time
-	sub    *subscription.EventSub // Event subscription
+	cr     ethereum.ChainReader            // chain reader to read block time
+	sub    *subscription.ResistantEventSub // Event subscription
 	subErr chan error
 	next   chan channel.AdjudicatorEvent // Event sink
 	err    chan error                    // error from subscription

--- a/backend/ethereum/channel/subscription.go
+++ b/backend/ethereum/channel/subscription.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 	"math/big"
-	"sync"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -71,7 +70,6 @@ type RegisteredSub struct {
 	subErr chan error
 	next   chan channel.AdjudicatorEvent // Event sink
 	err    chan error                    // error from subscription
-	closed sync.Once
 }
 
 func (r *RegisteredSub) updateNext(ctx context.Context, events chan *subscription.Event, a *Adjudicator) {
@@ -153,7 +151,7 @@ func (r *RegisteredSub) Next() channel.AdjudicatorEvent {
 
 // Close closes this subscription. Any pending calls to Next will return nil.
 func (r *RegisteredSub) Close() error {
-	r.closed.Do(r.sub.Close)
+	r.sub.Close()
 	return nil
 }
 

--- a/backend/ethereum/channel/withdraw.go
+++ b/backend/ethereum/channel/withdraw.go
@@ -60,7 +60,7 @@ func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.Adjudicat
 			fundingID := FundingIDs(req.Params.ID(), req.Params.Parts[req.Idx])[0]
 			events := make(chan *subscription.Event, 10)
 			subErr := make(chan error, 1)
-			sub, err := subscription.NewEventSub(ctx, a.ContractBackend, contract.contract, withdrawnEventType(fundingID), startBlockOffset)
+			sub, err := subscription.Subscribe(ctx, a.ContractBackend, contract.contract, withdrawnEventType(fundingID), startBlockOffset, TxFinalityDepth)
 			if err != nil {
 				return errors.WithMessage(err, "subscribing")
 			}

--- a/backend/ethereum/client/init_test.go
+++ b/backend/ethereum/client/init_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"perun.network/go-perun/apps/payment"
+	"perun.network/go-perun/backend/ethereum/channel"
 	"perun.network/go-perun/channel/test"
 	plogrus "perun.network/go-perun/log/logrus"
 )
@@ -29,4 +30,6 @@ func init() {
 	// TODO: This has to be set to the deployed app contract (or counterfactual
 	// address of it) when we start using it in tests.
 	test.SetAppRandomizer(new(payment.Randomizer))
+	// Fix the finality depth for testing.
+	channel.TxFinalityDepth = 3
 }

--- a/backend/ethereum/subscription/resistanteventsub.go
+++ b/backend/ethereum/subscription/resistanteventsub.go
@@ -91,7 +91,7 @@ func NewResistantEventSub(ctx context.Context, sub *EventSub, cr ethereum.ChainR
 	fd.SetUint64(finalityDepth)
 	ret := &ResistantEventSub{
 		sub:           sub,
-		lastBlockNum:  last.Number,
+		lastBlockNum:  new(big.Int).Set(last.Number),
 		heads:         heads,
 		headSub:       headSub,
 		finalityDepth: fd,

--- a/backend/ethereum/subscription/resistanteventsub_test.go
+++ b/backend/ethereum/subscription/resistanteventsub_test.go
@@ -38,7 +38,7 @@ var event = func() *subscription.Event {
 }
 
 // Defines a soft maximum value for the finality that tests will use.
-// Must be divisible by 2 and greater than 1.
+// Must be divisible by 2 and greater than 2.
 const maxFinality = 20
 
 // TestResistantEventSub_Confirm tests that a TX is confirmed exactly
@@ -166,7 +166,7 @@ func TestResistantEventSub_ReorgRemove(t *testing.T) {
 	require := require.New(t)
 	s := test.NewTokenSetup(ctx, t, rng)
 
-	finality := rng.Int31n(maxFinality-2) + 2
+	finality := rng.Int31n(maxFinality-3) + 3
 	sub, err := subscription.Subscribe(ctx, s.CB, s.Contract, event, 0, uint64(finality))
 	require.NoError(err)
 	defer sub.Close()
@@ -182,7 +182,7 @@ func TestResistantEventSub_ReorgRemove(t *testing.T) {
 
 	NoEvent(require, sub)
 	// Verify that the event never arrives.
-	for i := 0; i < maxFinality; i++ {
+	for i := 0; i < int(finality); i++ {
 		s.SB.Commit()
 	}
 	time.Sleep(1 * time.Second) // give the event subscription time to catch up


### PR DESCRIPTION
Uses resistant event confirmation on *go-perun* in all locations.  
Currently i am having trouble with the `AdjudicatorSub`, which seems to make some end-to-end tests fail.  
Funder and Adjudicator tests themselves seem to work.

Closes #85 
Draft until #40 and #97 are closed.