### PR TITLE
Add functions to register new assets in ethereum funder implementation

### DIFF
--- a/backend/ethereum/channel/funder.go
+++ b/backend/ethereum/channel/funder.go
@@ -76,18 +76,6 @@ func NewFunder(backend ContractBackend) *Funder {
 	}
 }
 
-// copy returns a copy of the funder.
-func (f *Funder) copy() (_f *Funder) {
-	_f = NewFunder(f.ContractBackend)
-	for k, v := range f.accounts {
-		_f.accounts[k] = v
-	}
-	for k, v := range f.depositors {
-		_f.depositors[k] = v
-	}
-	return
-}
-
 // RegisterAsset registers the depositor and account for the specified asset in
 // the funder.
 //
@@ -126,19 +114,6 @@ func (f *Funder) IsAssetRegistered(asset Asset) (Depositor, accounts.Account, bo
 		return f.depositors[asset], acc, true
 	}
 	return nil, accounts.Account{}, false
-}
-
-// WithDepositor creates a copy of the funder and assigns a depositor for the
-// specified asset. Transactions by the depositor will be done using the
-// specified account.
-func (f *Funder) WithDepositor(asset Asset, d Depositor, acc accounts.Account) (_f *Funder) {
-	f.mtx.Lock()
-	_f = f.copy()
-	f.mtx.Unlock()
-
-	_f.accounts[asset] = acc
-	_f.depositors[asset] = d
-	return
 }
 
 // Fund implements the channel.Funder interface. It funds all assets in

--- a/backend/ethereum/channel/funder_test.go
+++ b/backend/ethereum/channel/funder_test.go
@@ -165,7 +165,7 @@ func testFunderCrossOverFunding(t *testing.T, n int) {
 		i, funder := i, funder
 		go ct.StageN("funding", n, func(rt pkgtest.ConcT) {
 			req := channel.NewFundingReq(params, &channel.State{Allocation: *alloc}, channel.Index(i), agreement)
-			numTx, err := funders[0].NumTX(*req)
+			numTx, err := funders[i].NumTX(*req)
 			require.NoError(t, err)
 			diff, err := test.NonceDiff(parts[i], funder, func() error {
 				return funder.Fund(ctx, *req)

--- a/backend/ethereum/channel/funder_test.go
+++ b/backend/ethereum/channel/funder_test.go
@@ -402,9 +402,9 @@ func newNFunders(
 		simBackend.FundAddress(ctx, ethwallet.AsEthAddr(parts[i]))
 		fundERC20(ctx, cb, *tokenAcc, ethwallet.AsEthAddr(parts[i]), token, asset2)
 
-		funders[i] = ethchannel.NewFunder(cb).
-			WithDepositor(asset1, ethchannel.NewETHDepositor(), acc).
-			WithDepositor(asset2, ethchannel.NewERC20Depositor(token), acc)
+		funders[i] = ethchannel.NewFunder(cb)
+		require.True(t, funders[i].RegisterAsset(asset1, ethchannel.NewETHDepositor(), acc))
+		require.True(t, funders[i].RegisterAsset(asset2, ethchannel.NewERC20Depositor(token), acc))
 	}
 
 	// The SimBackend advances 10 sec per transaction/block, so generously add 20

--- a/backend/ethereum/channel/test/setup.go
+++ b/backend/ethereum/channel/test/setup.go
@@ -104,7 +104,8 @@ func NewSetup(t *testing.T, rng *rand.Rand, n int) *Setup {
 		s.SimBackend.FundAddress(ctx, s.Accs[i].Account.Address)
 		s.Recvs[i] = ksWallet.NewRandomAccount(rng).Address().(*ethwallet.Address)
 		cb := ethchannel.NewContractBackend(s.SimBackend, keystore.NewTransactor(*ksWallet, types.NewEIP155Signer(big.NewInt(1337))))
-		s.Funders[i] = ethchannel.NewFunder(cb).WithDepositor(asset, ethchannel.NewETHDepositor(), s.Accs[i].Account)
+		s.Funders[i] = ethchannel.NewFunder(cb)
+		require.True(t, s.Funders[i].RegisterAsset(asset, ethchannel.NewETHDepositor(), s.Accs[i].Account))
 		s.Adjs[i] = NewSimAdjudicator(cb, adjudicator, common.Address(*s.Recvs[i]), s.Accs[i].Account)
 	}
 


### PR DESCRIPTION
- As these methods provide convenience for the user (to register assets after funder is initialized) and are not required by the framework itself for the process of funding, they are not added to the `Funder` interface.

- Use the `RegisterAsset` method in place of `WithDepositor`, as the newly added method provides the same functionality without making a copy of the funder.

- Also, fixed a bug in `funder_test.go`. See the last before commit for details. 