### PR TITLE
Draft channel redesign

### DIFF
--- a/backend/ethereum/channel/adjudicator_test.go
+++ b/backend/ethereum/channel/adjudicator_test.go
@@ -88,13 +88,15 @@ func TestSubscribeRegistered(t *testing.T) {
 	defer sub.Close()
 	// Now test the register function
 	tx := testSignState(t, s.Accs, params, state)
-	req := channel.AdjudicatorReq{
-		Params: params,
-		Acc:    s.Accs[0],
-		Idx:    channel.Index(0),
-		Tx:     tx,
+	req := channel.RegisterReq{
+		AdjudicatorReq: channel.AdjudicatorReq{
+			Params: params,
+			Acc:    s.Accs[0],
+			Idx:    channel.Index(0),
+			Tx:     tx,
+		},
 	}
-	assert.NoError(t, adj.Register(txCtx, req, nil), "Registering state should succeed")
+	assert.NoError(t, adj.Register(txCtx, req), "Registering state should succeed")
 	event := sub.Next()
 	assert.Equal(t, event, registered.Next(), "Events should be equal")
 	assert.NoError(t, registered.Close(), "Closing event channel should not error")

--- a/backend/ethereum/channel/conclude_test.go
+++ b/backend/ethereum/channel/conclude_test.go
@@ -287,7 +287,10 @@ func withdraw(ctx context.Context, adj *test.SimAdjudicator, accounts []*keystor
 			Secondary: i != 0,
 		}
 
-		if err := adj.Withdraw(ctx, req, subStates); err != nil {
+		if err := adj.Withdraw(ctx, channel.WithdrawReq{
+			AdjudicatorReq: req,
+			SubChannels:    subStates,
+		}); err != nil {
 			return err
 		}
 	}

--- a/backend/ethereum/channel/conclude_test.go
+++ b/backend/ethereum/channel/conclude_test.go
@@ -76,15 +76,17 @@ func testConcludeFinal(t *testing.T, numParts int) {
 	for i := 0; i < numParts; i++ {
 		i := i
 		go ct.StageN("register", numParts, func(t pkgtest.ConcT) {
-			req := channel.AdjudicatorReq{
-				Params:    params,
-				Acc:       s.Accs[i],
-				Idx:       channel.Index(i),
-				Tx:        tx,
-				Secondary: (i != initiator),
+			req := channel.RegisterReq{
+				AdjudicatorReq: channel.AdjudicatorReq{
+					Params:    params,
+					Acc:       s.Accs[i],
+					Idx:       channel.Index(i),
+					Tx:        tx,
+					Secondary: (i != initiator),
+				},
 			}
 			diff, err := test.NonceDiff(s.Accs[i].Address(), s.Adjs[i], func() error {
-				return s.Adjs[i].Register(ctx, req, nil)
+				return s.Adjs[i].Register(ctx, req)
 			})
 			require.NoError(t, err, "Withdrawing should succeed")
 			if !req.Secondary {
@@ -251,14 +253,17 @@ func register(ctx context.Context, adj *test.SimAdjudicator, accounts []*keystor
 		return err
 	}
 
-	req := channel.AdjudicatorReq{
-		Params:    ch.params,
-		Acc:       accounts[0],
-		Idx:       0,
-		Tx:        tx,
-		Secondary: false,
+	req := channel.RegisterReq{
+		AdjudicatorReq: channel.AdjudicatorReq{
+			Params:    ch.params,
+			Acc:       accounts[0],
+			Idx:       0,
+			Tx:        tx,
+			Secondary: false,
+		},
+		SubChannels: sub,
 	}
-	return adj.Register(ctx, req, sub)
+	return adj.Register(ctx, req)
 }
 
 func addSubStates(subStates channel.StateMap, channels ...paramsAndState) {

--- a/backend/ethereum/channel/register.go
+++ b/backend/ethereum/channel/register.go
@@ -24,11 +24,11 @@ import (
 
 // Register registers a state on-chain.
 // If the state is a final state, register becomes a no-op.
-func (a *Adjudicator) Register(ctx context.Context, req channel.AdjudicatorReq, subChannels []channel.SignedState) error {
+func (a *Adjudicator) Register(ctx context.Context, req channel.RegisterReq) error {
 	if req.Tx.State.IsFinal {
-		return a.registerFinal(ctx, req)
+		return a.registerFinal(ctx, req.AdjudicatorReq)
 	}
-	return a.registerNonFinal(ctx, req, subChannels)
+	return a.registerNonFinal(ctx, req.AdjudicatorReq, req.SubChannels)
 }
 
 // registerFinal registers a final state. It ensures that the final state is

--- a/backend/ethereum/channel/register_test.go
+++ b/backend/ethereum/channel/register_test.go
@@ -107,11 +107,13 @@ func registerMultiple(t *testing.T, numParts int, parallel bool) {
 			subs[i] = sub
 
 			// register
-			req := channel.AdjudicatorReq{
-				Params: params,
-				Tx:     tx,
+			req := channel.RegisterReq{
+				AdjudicatorReq: channel.AdjudicatorReq{
+					Params: params,
+					Tx:     tx,
+				},
 			}
-			err = adj.Register(ctx, req, nil)
+			err = adj.Register(ctx, req)
 			require.True(t, err == nil || ethchannel.IsErrTxFailed(err), "Registering peer %d", i)
 		}
 		if parallel {
@@ -163,13 +165,15 @@ func TestRegister_FinalState(t *testing.T) {
 	defer sub.Close()
 	// register
 	tx := testSignState(t, s.Accs, params, state)
-	req := channel.AdjudicatorReq{
-		Params: params,
-		Acc:    s.Accs[0],
-		Idx:    channel.Index(0),
-		Tx:     tx,
+	req := channel.RegisterReq{
+		AdjudicatorReq: channel.AdjudicatorReq{
+			Params: params,
+			Acc:    s.Accs[0],
+			Idx:    channel.Index(0),
+			Tx:     tx,
+		},
 	}
-	assert.NoError(t, adj.Register(ctx, req, nil), "Registering final state should succeed")
+	assert.NoError(t, adj.Register(ctx, req), "Registering final state should succeed")
 	event := sub.Next()
 	assert.NotEqual(t, event, &channel.RegisteredEvent{}, "registering should return valid event")
 	assert.True(t, event.Timeout().IsElapsed(ctx), "registering final state should return elapsed timeout")
@@ -199,11 +203,13 @@ func TestRegister_CancelledContext(t *testing.T) {
 	defer sub.Close()
 	// register
 	tx := testSignState(t, s.Accs, params, state)
-	req := channel.AdjudicatorReq{
-		Params: params,
-		Acc:    s.Accs[0],
-		Idx:    channel.Index(0),
-		Tx:     tx,
+	req := channel.RegisterReq{
+		AdjudicatorReq: channel.AdjudicatorReq{
+			Params: params,
+			Acc:    s.Accs[0],
+			Idx:    channel.Index(0),
+			Tx:     tx,
+		},
 	}
-	assert.Error(t, adj.Register(ctx, req, nil), "Registering with canceled context should error")
+	assert.Error(t, adj.Register(ctx, req), "Registering with canceled context should error")
 }

--- a/backend/ethereum/channel/withdraw.go
+++ b/backend/ethereum/channel/withdraw.go
@@ -36,12 +36,12 @@ import (
 
 // Withdraw ensures that a channel has been concluded and the final outcome
 // withdrawn from the asset holders.
-func (a *Adjudicator) Withdraw(ctx context.Context, req channel.AdjudicatorReq, subStates channel.StateMap) error {
-	if err := a.ensureConcluded(ctx, req, subStates); err != nil {
+func (a *Adjudicator) Withdraw(ctx context.Context, req channel.WithdrawReq) error {
+	if err := a.ensureConcluded(ctx, req.AdjudicatorReq, req.SubChannels); err != nil {
 		return errors.WithMessage(err, "ensure Concluded")
 	}
 
-	return errors.WithMessage(a.ensureWithdrawn(ctx, req), "ensure Withdrawn")
+	return errors.WithMessage(a.ensureWithdrawn(ctx, req.AdjudicatorReq), "ensure Withdrawn")
 }
 
 func (a *Adjudicator) ensureWithdrawn(ctx context.Context, req channel.AdjudicatorReq) error {

--- a/backend/ethereum/channel/withdraw_test.go
+++ b/backend/ethereum/channel/withdraw_test.go
@@ -90,7 +90,10 @@ func withdrawMultipleConcurrentFinal(t *testing.T, numParts int, parallel bool) 
 					Idx:    channel.Index(i),
 					Tx:     tx,
 				}
-				err := s.Adjs[i].Withdraw(ctx, req, nil)
+				err := s.Adjs[i].Withdraw(ctx, channel.WithdrawReq{
+					AdjudicatorReq: req,
+					SubChannels:    nil,
+				})
 				assert.NoError(t, err, "Withdrawing should succeed")
 			}(i)
 		}
@@ -104,7 +107,9 @@ func withdrawMultipleConcurrentFinal(t *testing.T, numParts int, parallel bool) 
 				Idx:    channel.Index(i),
 				Tx:     tx,
 			}
-			err := s.Adjs[i].Withdraw(ctx, req, nil)
+			err := s.Adjs[i].Withdraw(ctx, channel.WithdrawReq{
+				AdjudicatorReq: req,
+			})
 			assert.NoError(t, err, "Withdrawing should succeed")
 		}
 	}
@@ -163,7 +168,9 @@ func testWithdrawZeroBalance(t *testing.T, n int) {
 		req.Idx = channel.Index(i)
 		// check that the nonce stays the same for zero balance withdrawals
 		diff, err := test.NonceDiff(s.Accs[i].Address(), adj, func() error {
-			return adj.Withdraw(context.Background(), req.AdjudicatorReq, nil)
+			return adj.Withdraw(context.Background(), channel.WithdrawReq{
+				AdjudicatorReq: req.AdjudicatorReq,
+			})
 		})
 		require.NoError(t, err)
 		if i%2 == 0 {
@@ -197,7 +204,9 @@ func TestWithdraw(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 		req.Tx = testSignState(t, s.Accs, params, state)
-		err := s.Adjs[0].Withdraw(ctx, req, nil)
+		err := s.Adjs[0].Withdraw(ctx, channel.WithdrawReq{
+			AdjudicatorReq: req,
+		})
 
 		if shouldWork {
 			assert.NoError(t, err, "Withdrawing should work")
@@ -265,7 +274,7 @@ func TestWithdrawNonFinal(t *testing.T) {
 		"registering non-final state should have non-elapsed timeout")
 	assert.NoError(reg.Timeout().Wait(ctx))
 	assert.True(reg.Timeout().IsElapsed(ctx), "timeout should have elapsed after Wait()")
-	assert.NoError(adj.Withdraw(ctx, req.AdjudicatorReq, nil),
+	assert.NoError(adj.Withdraw(ctx, channel.WithdrawReq{AdjudicatorReq: req.AdjudicatorReq}),
 		"withdrawing should succeed after waiting for timeout")
 }
 

--- a/channel/adjudicator.go
+++ b/channel/adjudicator.go
@@ -47,7 +47,7 @@ type (
 		// account that a peer might already have concluded the same channel.
 		// If the channel has locked funds in sub-channels, the states of the
 		// corresponding sub-channels need to be supplied additionally.
-		Withdraw(context.Context, AdjudicatorReq, StateMap) error
+		Withdraw(context.Context, WithdrawReq) error
 
 		// Progress should try to progress an on-chain registered state to the new
 		// state given in ProgressReq. The Transaction field only needs to
@@ -97,6 +97,12 @@ type (
 		AdjudicatorReq            // Tx should refer to the currently registered state
 		NewState       *State     // New state to progress into
 		Sig            wallet.Sig // Own signature on the new state
+	}
+
+	// WithdrawReq constitutes the withdraw call data.
+	WithdrawReq struct {
+		AdjudicatorReq
+		SubChannels StateMap
 	}
 
 	// An AdjudicatorSubscription is a subscription to AdjudicatorEvents for a

--- a/channel/adjudicator.go
+++ b/channel/adjudicator.go
@@ -39,7 +39,7 @@ type (
 		// Register should register the given ledger channel state on-chain.
 		// If the channel has locked funds into sub-channels, the corresponding
 		// signed sub-channel states must be provided.
-		Register(context.Context, AdjudicatorReq, []SignedState) error
+		Register(context.Context, RegisterReq) error
 
 		// Withdraw should conclude and withdraw the registered state, so that the
 		// final outcome is set on the asset holders and funds are withdrawn
@@ -76,6 +76,12 @@ type (
 		Tx        Transaction
 		Idx       Index // Always the own index
 		Secondary bool  // Optimized secondary call protocol
+	}
+
+	// RegisterReq constitutes the register call data.
+	RegisterReq struct {
+		AdjudicatorReq
+		SubChannels []SignedState
 	}
 
 	// SignedState represents a signed channel state including parameters.

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -119,7 +119,10 @@ func (c *Channel) Register(ctx context.Context) error {
 		return errors.WithMessage(err, "gathering sub-channel states")
 	}
 
-	err = c.adjudicator.Register(ctx, c.machine.AdjudicatorReq(), subStates)
+	err = c.adjudicator.Register(ctx, channel.RegisterReq{
+		AdjudicatorReq: c.machine.AdjudicatorReq(),
+		SubChannels:    subStates,
+	})
 	if err != nil {
 		return errors.WithMessage(err, "calling Register")
 	}

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -204,7 +204,10 @@ func (c *Channel) SettleWithSubchannels(ctx context.Context, subStates channel.S
 	case c.IsLedgerChannel():
 		req := c.machine.AdjudicatorReq()
 		req.Secondary = secondary
-		if err := c.adjudicator.Withdraw(ctx, req, subStates); err != nil {
+		if err := c.adjudicator.Withdraw(ctx, channel.WithdrawReq{
+			AdjudicatorReq: req,
+			SubChannels:    subStates,
+		}); err != nil {
 			return errors.WithMessage(err, "calling Withdraw")
 		}
 	case c.IsSubChannel():

--- a/client/client_role_test.go
+++ b/client/client_role_test.go
@@ -89,7 +89,7 @@ func (f *logFunderWithDelay) Fund(_ context.Context, req channel.FundingReq) err
 	return nil
 }
 
-func (a *logAdjudicator) Register(_ context.Context, req channel.AdjudicatorReq, subChannels []channel.SignedState) error {
+func (a *logAdjudicator) Register(_ context.Context, req channel.RegisterReq) error {
 	a.log.Infof("Register: %v", req)
 	e := channel.NewRegisteredEvent(
 		req.Params.ID(),

--- a/client/client_role_test.go
+++ b/client/client_role_test.go
@@ -111,8 +111,8 @@ func (a *logAdjudicator) Progress(_ context.Context, req channel.ProgressReq) er
 	return nil
 }
 
-func (a *logAdjudicator) Withdraw(_ context.Context, req channel.AdjudicatorReq, subStates channel.StateMap) error {
-	a.log.Infof("Withdraw: %v, %v", req, subStates)
+func (a *logAdjudicator) Withdraw(_ context.Context, req channel.WithdrawReq) error {
+	a.log.Infof("Withdraw: %v, %v", req)
 	return nil
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -54,7 +54,7 @@ type DummyAdjudicator struct {
 	t *testing.T
 }
 
-func (d *DummyAdjudicator) Register(context.Context, channel.AdjudicatorReq, []channel.SignedState) error {
+func (d *DummyAdjudicator) Register(context.Context, channel.RegisterReq) error {
 	d.t.Error("DummyAdjudicator.Register called")
 	return errors.New("DummyAdjudicator.Register called")
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -64,7 +64,7 @@ func (d *DummyAdjudicator) Progress(context.Context, channel.ProgressReq) error 
 	return errors.New("DummyAdjudicator.Progress called")
 }
 
-func (d *DummyAdjudicator) Withdraw(context.Context, channel.AdjudicatorReq, channel.StateMap) error {
+func (d *DummyAdjudicator) Withdraw(context.Context, channel.WithdrawReq) error {
 	d.t.Error("DummyAdjudicator.Withdraw called")
 	return errors.New("DummyAdjudicator.Withdraw called")
 }

--- a/client/test/channel.go
+++ b/client/test/channel.go
@@ -184,10 +184,6 @@ func (ch *paymentChannel) settleImpl(secondary bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), ch.r.timeout)
 	defer cancel()
 
-	if ch.IsLedgerChannel() || !ch.State().IsFinal {
-		assert.NoError(ch.Register(ctx))
-	}
-
 	assert.NoError(ch.Settle(ctx, secondary))
 	ch.assertBals(ch.State())
 

--- a/client/test/mallory.go
+++ b/client/test/mallory.go
@@ -54,7 +54,8 @@ func (r *Mallory) exec(_cfg ExecConfig, ch *paymentChannel) {
 	assert := assert.New(r.t)
 	we, _ := r.Idxs(cfg.Peers())
 	// AdjudicatorReq for version 0
-	req0 := client.NewTestChannel(ch.Channel).AdjudicatorReq()
+	testCh := client.NewTestChannel(ch.Channel)
+	req0 := testCh.AdjudicatorReq()
 
 	// 1st stage - channel controller set up
 	r.waitStage()
@@ -71,7 +72,7 @@ func (r *Mallory) exec(_cfg ExecConfig, ch *paymentChannel) {
 	regCtx, regCancel := context.WithTimeout(context.Background(), r.timeout)
 	defer regCancel()
 	r.log.Debug("Registering version 0 state.")
-	assert.NoError(r.setup.Adjudicator.Register(regCtx, channel.RegisterReq{AdjudicatorReq: req0}))
+	assert.NoError(testCh.RegisterState(regCtx, req0))
 
 	// within the challenge duration, Carol should refute.
 	subCtx, subCancel := context.WithTimeout(context.Background(), r.timeout+challengeDuration)

--- a/client/test/mallory.go
+++ b/client/test/mallory.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"perun.network/go-perun/channel"
 	"perun.network/go-perun/client"
 )
 
@@ -70,7 +71,7 @@ func (r *Mallory) exec(_cfg ExecConfig, ch *paymentChannel) {
 	regCtx, regCancel := context.WithTimeout(context.Background(), r.timeout)
 	defer regCancel()
 	r.log.Debug("Registering version 0 state.")
-	assert.NoError(r.setup.Adjudicator.Register(regCtx, req0, nil))
+	assert.NoError(r.setup.Adjudicator.Register(regCtx, channel.RegisterReq{AdjudicatorReq: req0}))
 
 	// within the challenge duration, Carol should refute.
 	subCtx, subCancel := context.WithTimeout(context.Background(), r.timeout+challengeDuration)

--- a/client/test/mallory.go
+++ b/client/test/mallory.go
@@ -98,7 +98,7 @@ func (r *Mallory) exec(_cfg ExecConfig, ch *paymentChannel) {
 
 	wdCtx, wdCancel := context.WithTimeout(context.Background(), r.timeout)
 	defer wdCancel()
-	err = r.setup.Adjudicator.Withdraw(wdCtx, req0, nil)
+	err = r.setup.Adjudicator.Withdraw(wdCtx, channel.WithdrawReq{AdjudicatorReq: req0})
 	assert.Error(err, "withdrawing should fail because Carol should have refuted.")
 
 	// settling current version should work

--- a/client/test/progression.go
+++ b/client/test/progression.go
@@ -91,14 +91,8 @@ func (r *Paul) exec(_cfg ExecConfig, ch *paymentChannel) {
 
 	r.waitStage() // wait for setup complete
 
-	// register
-	assert.NoError(ch.Register(ctx), "registering")
-	regEvent := <-r.registered
-
-	assert.NoError(regEvent.Timeout().Wait(ctx), "waiting for refutation timeout")
-
 	// progress
-	assert.NoError(ch.ProgressBy(ctx, func(s *channel.State) {
+	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) {
 		bal := func(user channel.Index) int64 {
 			return s.Balances[assetIdx][user].Int64()
 		}
@@ -168,7 +162,7 @@ func (r *Paula) exec(_cfg ExecConfig, ch *paymentChannel, _ *acceptNextPropHandl
 	r.t.Logf("%v received progression confirmation 1", r.setup.Name)
 
 	// we progress
-	assert.NoError(ch.ProgressBy(ctx, func(s *channel.State) {
+	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) {
 		bal := func(user channel.Index) int64 {
 			return s.Balances[assetIdx][user].Int64()
 		}

--- a/client/testchannel.go
+++ b/client/testchannel.go
@@ -14,7 +14,12 @@
 
 package client
 
-import "perun.network/go-perun/channel"
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"perun.network/go-perun/channel"
+)
 
 // TestChannel grants access to the `AdjudicatorRequest` which is otherwise
 // hidden by `Channel`. Behaves like a `Channel` in all other cases.
@@ -32,4 +37,26 @@ func NewTestChannel(c *Channel) *TestChannel {
 // AdjudicatorReq returns the `AdjudicatorReq` of the underlying machine.
 func (c *TestChannel) AdjudicatorReq() channel.AdjudicatorReq {
 	return c.machine.AdjudicatorReq()
+}
+
+// RegisterState registers the given state.
+func (c *TestChannel) RegisterState(ctx context.Context, req channel.AdjudicatorReq) (err error) {
+	// Lock machines of channel and all subchannels recursively.
+	if !c.machMtx.TryLockCtx(ctx) {
+		return errors.Errorf("locking machine mutex in time: %v", ctx.Err())
+	}
+	defer c.machMtx.Unlock()
+
+	err = c.machine.SetRegistering(ctx)
+	if err != nil {
+		return
+	}
+
+	err = c.Channel.adjudicator.Register(ctx, channel.RegisterReq{AdjudicatorReq: req})
+	if err != nil {
+		return
+	}
+
+	err = c.machine.SetRegistered(ctx)
+	return
 }


### PR DESCRIPTION
This PR explores possibilities to streamline channel operation. Usage of the channel became more complicated since sub-channels and app channels were introduced.

One complication was caused by the fact that the register call was exposed and needed to be called manually before enforcing on-chain state progression.

This PR proposes to simplify the process of on-chain progression:

- Rename Channel.Progress to Channel.ForceUpdate: This conveys more clearly that the functionality is related to "Channel.Update".
- Implicitly register state on `ForceUpdate`: This simplifies the usage because the user does need to take care of manually registering before calling `ForceUpdate`.

The PR also includes parameter consolidation for `Adjudicator.Register` and `Withdraw`, similar to `Adjudicator.Progress`.