### PR TITLE
 Modify Adjudicator.Subscribe to take channel.ID instead of channel.Params

### DIFF
--- a/backend/ethereum/channel/adjudicator_test.go
+++ b/backend/ethereum/channel/adjudicator_test.go
@@ -73,7 +73,7 @@ func TestSubscribeRegistered(t *testing.T) {
 	// Set up subscription
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	registered, err := s.Adjs[0].Subscribe(ctx, params)
+	registered, err := s.Adjs[0].Subscribe(ctx, params.ID())
 	require.NoError(t, err, "Subscribing to valid params should not error")
 	// we need to properly fund the channel
 	txCtx, txCancel := context.WithTimeout(context.Background(), defaultTxTimeout)
@@ -83,7 +83,7 @@ func TestSubscribeRegistered(t *testing.T) {
 	require.NoError(t, s.Funders[0].Fund(txCtx, *reqFund), "funding should succeed")
 	// create subscription
 	adj := s.Adjs[0]
-	sub, err := adj.Subscribe(ctx, params)
+	sub, err := adj.Subscribe(ctx, params.ID())
 	require.NoError(t, err)
 	defer sub.Close()
 	// Now test the register function
@@ -101,7 +101,7 @@ func TestSubscribeRegistered(t *testing.T) {
 	assert.Nil(t, registered.Next(), "Next on closed channel should produce nil")
 	assert.NoError(t, registered.Err(), "Closing should produce no error")
 	// Setup a new subscription
-	registered2, err := adj.Subscribe(ctx, params)
+	registered2, err := adj.Subscribe(ctx, params.ID())
 	assert.NoError(t, err, "registering two subscriptions should not fail")
 	assert.Equal(t, event, registered2.Next(), "Events should be equal")
 	assert.NoError(t, registered2.Close(), "Closing event channel should not error")

--- a/backend/ethereum/channel/conclude_test.go
+++ b/backend/ethereum/channel/conclude_test.go
@@ -160,7 +160,7 @@ func TestAdjudicator_ConcludeWithSubChannels(t *testing.T) {
 
 	// 2. wait until ready to conclude
 
-	sub, err := adj.Subscribe(ctx, ledgerChannel.params)
+	sub, err := adj.Subscribe(ctx, ledgerChannel.params.ID())
 	require.NoError(err)
 	require.NoError(sub.Next().Timeout().Wait(ctx))
 	sub.Close()

--- a/backend/ethereum/channel/register_test.go
+++ b/backend/ethereum/channel/register_test.go
@@ -102,7 +102,7 @@ func registerMultiple(t *testing.T, numParts int, parallel bool) {
 
 			// create subscription
 			adj := s.Adjs[i]
-			sub, err := adj.Subscribe(ctx, params)
+			sub, err := adj.Subscribe(ctx, params.ID())
 			require.NoError(t, err)
 			subs[i] = sub
 
@@ -158,7 +158,7 @@ func TestRegister_FinalState(t *testing.T) {
 	defer cancel()
 	// create subscription
 	adj := s.Adjs[0]
-	sub, err := adj.Subscribe(ctx, params)
+	sub, err := adj.Subscribe(ctx, params.ID())
 	require.NoError(t, err)
 	defer sub.Close()
 	// register
@@ -194,7 +194,7 @@ func TestRegister_CancelledContext(t *testing.T) {
 	cancel()
 	// create subscription
 	adj := s.Adjs[0]
-	sub, err := adj.Subscribe(ctx, params)
+	sub, err := adj.Subscribe(ctx, params.ID())
 	require.NoError(t, err)
 	defer sub.Close()
 	// register

--- a/backend/ethereum/channel/subscription.go
+++ b/backend/ethereum/channel/subscription.go
@@ -33,14 +33,14 @@ import (
 )
 
 // Subscribe returns a new AdjudicatorSubscription to adjudicator events.
-func (a *Adjudicator) Subscribe(ctx context.Context, params *channel.Params) (channel.AdjudicatorSubscription, error) {
+func (a *Adjudicator) Subscribe(ctx context.Context, chID channel.ID) (channel.AdjudicatorSubscription, error) {
 	subErr := make(chan error, 1)
 	events := make(chan *subscription.Event, 10)
 	eFact := func() *subscription.Event {
 		return &subscription.Event{
 			Name:   bindings.Events.AdjChannelUpdate,
 			Data:   new(adjudicator.AdjudicatorChannelUpdate),
-			Filter: [][]interface{}{{params.ID()}},
+			Filter: [][]interface{}{{chID}},
 		}
 	}
 	sub, err := subscription.Subscribe(ctx, a.ContractBackend, a.bound, eFact, startBlockOffset, TxFinalityDepth)

--- a/backend/ethereum/channel/test/adjudicator.go
+++ b/backend/ethereum/channel/test/adjudicator.go
@@ -52,8 +52,8 @@ func NewSimAdjudicator(backend ethchannel.ContractBackend, contract common.Addre
 
 // Subscribe returns a RegisteredEvent subscription on the simulated
 // blockchain backend.
-func (a *SimAdjudicator) Subscribe(ctx context.Context, params *channel.Params) (channel.AdjudicatorSubscription, error) {
-	sub, err := a.Adjudicator.Subscribe(ctx, params)
+func (a *SimAdjudicator) Subscribe(ctx context.Context, chID channel.ID) (channel.AdjudicatorSubscription, error) {
+	sub, err := a.Adjudicator.Subscribe(ctx, chID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/ethereum/channel/withdraw_test.go
+++ b/backend/ethereum/channel/withdraw_test.go
@@ -243,7 +243,7 @@ func TestWithdrawNonFinal(t *testing.T) {
 
 	// create subscription
 	adj := s.Adjs[0]
-	sub, err := adj.Subscribe(ctx, params)
+	sub, err := adj.Subscribe(ctx, params.ID())
 	require.NoError(t, err)
 	defer sub.Close()
 

--- a/channel/adjudicator.go
+++ b/channel/adjudicator.go
@@ -60,7 +60,7 @@ type (
 		// The context should only be used to establish the subscription. The
 		// framework will call Close on the subscription once the respective channel
 		// controller shuts down.
-		Subscribe(context.Context, *Params) (AdjudicatorSubscription, error)
+		Subscribe(context.Context, ID) (AdjudicatorSubscription, error)
 	}
 
 	// An AdjudicatorReq collects all necessary information to make calls to the

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -48,7 +48,7 @@ func (c *Channel) Watch(h AdjudicatorEventHandler) error {
 
 	// Subscribe to state changes
 	ctx := c.Ctx()
-	sub, err := c.adjudicator.Subscribe(ctx, c.Params())
+	sub, err := c.adjudicator.Subscribe(ctx, c.Params().ID())
 	if err != nil {
 		return errors.WithMessage(err, "subscribing to adjudicator state changes")
 	}
@@ -420,7 +420,7 @@ func (c *Channel) ensureRegistered(ctx context.Context) error {
 	registeredEvents := make(chan *channel.RegisteredEvent)
 
 	// Start event subscription.
-	sub, err := c.adjudicator.Subscribe(ctx, c.Params())
+	sub, err := c.adjudicator.Subscribe(ctx, c.Params().ID())
 	if err != nil {
 		return errors.WithMessage(err, "subscribing to adjudicator events")
 	}

--- a/client/test/backend.go
+++ b/client/test/backend.go
@@ -267,8 +267,8 @@ func (b *MockBackend) setBalance(p wallet.Address, a channel.Asset, v *big.Int) 
 }
 
 // Subscribe creates an event subscription.
-func (b *MockBackend) Subscribe(ctx context.Context, params *channel.Params) (channel.AdjudicatorSubscription, error) {
-	b.log.Infof("SubscribeRegistered: %+v", params)
+func (b *MockBackend) Subscribe(ctx context.Context, chID channel.ID) (channel.AdjudicatorSubscription, error) {
+	b.log.Infof("SubscribeRegistered: %+v", chID)
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -278,10 +278,10 @@ func (b *MockBackend) Subscribe(ctx context.Context, params *channel.Params) (ch
 		events: make(chan channel.AdjudicatorEvent, 1),
 		err:    make(chan error, 1),
 	}
-	b.eventSubs[params.ID()] = append(b.eventSubs[params.ID()], sub.events)
+	b.eventSubs[chID] = append(b.eventSubs[chID], sub.events)
 
 	// Feed latest event if any.
-	if e, ok := b.latestEvents[params.ID()]; ok {
+	if e, ok := b.latestEvents[chID]; ok {
 		sub.events <- e
 	}
 

--- a/client/test/mallory.go
+++ b/client/test/mallory.go
@@ -75,7 +75,7 @@ func (r *Mallory) exec(_cfg ExecConfig, ch *paymentChannel) {
 	// within the challenge duration, Carol should refute.
 	subCtx, subCancel := context.WithTimeout(context.Background(), r.timeout+challengeDuration)
 	defer subCancel()
-	sub, err := r.setup.Adjudicator.Subscribe(subCtx, ch.Params())
+	sub, err := r.setup.Adjudicator.Subscribe(subCtx, ch.Params().ID())
 	assert.NoError(err)
 
 	// 3rd stage - wait until Carol has refuted

--- a/client/virtual_channel.go
+++ b/client/virtual_channel.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
@@ -104,7 +105,7 @@ func (c *Channel) watchVirtual() error {
 
 	// Subscribe to state changes
 	ctx := c.Ctx()
-	sub, err := c.adjudicator.Subscribe(ctx, c.Params())
+	sub, err := c.adjudicator.Subscribe(ctx, c.Params().ID())
 	if err != nil {
 		return errors.WithMessage(err, "subscribing to adjudicator state changes")
 	}


### PR DESCRIPTION
- Previously, Adjudicator.Subscribe was taking channel.Params, while it
  was using only the ID contained in the params.

- So, modified the API to take only the required parameter.

Resolves #173.
