### PR TITLE
193 rename wallettest variable

### DIFF
--- a/backend/ethereum/wallet/hd/wallet_test.go
+++ b/backend/ethereum/wallet/hd/wallet_test.go
@@ -73,7 +73,7 @@ func TestNewWallet(t *testing.T) {
 func TestSignWithMissingKey(t *testing.T) {
 	setup, accsWallet, _ := newSetup(t, pkgtest.Prng(t))
 
-	missingAddr := common.BytesToAddress(setup.AddressBytes)
+	missingAddr := common.BytesToAddress(setup.AddressEncoded)
 	acc := hd.NewAccountFromEth(accsWallet, accounts.Account{Address: missingAddr})
 	require.NotNil(t, acc)
 	_, err := acc.SignData(setup.DataToSign)
@@ -83,7 +83,7 @@ func TestSignWithMissingKey(t *testing.T) {
 func TestUnlock(t *testing.T) {
 	setup, _, hdWallet := newSetup(t, pkgtest.Prng(t))
 
-	missingAddr := common.BytesToAddress(setup.AddressBytes)
+	missingAddr := common.BytesToAddress(setup.AddressEncoded)
 	_, err := hdWallet.Unlock(ethwallet.AsWalletAddr(missingAddr))
 	assert.Error(t, err, "should error on unlocking missing address")
 
@@ -98,7 +98,7 @@ func TestContains(t *testing.T) {
 
 	assert.False(t, hdWallet.Contains(common.Address{}), "should not contain nil account")
 
-	missingAddr := common.BytesToAddress(setup.AddressBytes)
+	missingAddr := common.BytesToAddress(setup.AddressEncoded)
 	assert.False(t, hdWallet.Contains(missingAddr), "should not contain address of the missing account")
 
 	validAcc, err := setup.UnlockedAccount()
@@ -131,7 +131,7 @@ func newSetup(t require.TestingT, prng *rand.Rand) (*test.Setup, accounts.Wallet
 	return &test.Setup{
 		UnlockedAccount: func() (wallet.Account, error) { return acc, nil },
 		Backend:         new(ethwallet.Backend),
-		AddressBytes:    sampleBytes,
+		AddressEncoded:  sampleBytes,
 		DataToSign:      dataToSign,
 	}, rawHDWallet, hdWallet
 }

--- a/backend/ethereum/wallet/keystore/wallet_test.go
+++ b/backend/ethereum/wallet/keystore/wallet_test.go
@@ -73,11 +73,11 @@ func TestBackend(t *testing.T) {
 
 	s := newSetup(t)
 
-	buff := bytes.NewReader(s.AddressBytes)
+	buff := bytes.NewReader(s.AddressEncoded)
 	addr, err := backend.DecodeAddress(buff)
 
 	assert.NoError(t, err, "NewAddress from Bytes should work")
-	assert.Equal(t, s.AddressBytes, addr.Bytes())
+	assert.Equal(t, s.AddressEncoded, addr.Bytes())
 
 	buff = bytes.NewReader([]byte(invalidAddr))
 	_, err = backend.DecodeAddress(buff)
@@ -92,7 +92,7 @@ func newSetup(t require.TestingT) *test.Setup {
 	return &test.Setup{
 		UnlockedAccount: func() (wallet.Account, error) { return acc, nil },
 		Backend:         new(ethwallet.Backend),
-		AddressBytes:    validAddrBytes,
+		AddressEncoded:  validAddrBytes,
 		DataToSign:      dataToSign,
 	}
 }

--- a/backend/ethereum/wallet/simple/wallet_test.go
+++ b/backend/ethereum/wallet/simple/wallet_test.go
@@ -55,7 +55,7 @@ func TestNewWallet(t *testing.T) {
 func TestUnlock(t *testing.T) {
 	setup, simpleWallet := newSetup(t, pkgtest.Prng(t))
 
-	missingAddr := common.BytesToAddress(setup.AddressBytes)
+	missingAddr := common.BytesToAddress(setup.AddressEncoded)
 	_, err := simpleWallet.Unlock(ethwallet.AsWalletAddr(missingAddr))
 	assert.Error(t, err, "should error on unlocking missing address")
 
@@ -68,7 +68,7 @@ func TestUnlock(t *testing.T) {
 func TestWallet_Contains(t *testing.T) {
 	setup, simpleWallet := newSetup(t, pkgtest.Prng(t))
 
-	missingAddr := common.BytesToAddress(setup.AddressBytes)
+	missingAddr := common.BytesToAddress(setup.AddressEncoded)
 	assert.False(t, simpleWallet.Contains(missingAddr))
 
 	validAcc, err := setup.UnlockedAccount()
@@ -112,7 +112,7 @@ func newSetup(t require.TestingT, prng *rand.Rand) (*test.Setup, *simple.Wallet)
 	return &test.Setup{
 		UnlockedAccount: func() (wallet.Account, error) { return acc, nil },
 		Backend:         new(ethwallet.Backend),
-		AddressBytes:    validAddrBytes,
+		AddressEncoded:  validAddrBytes,
 		DataToSign:      dataToSign,
 	}, simpleWallet
 }

--- a/backend/sim/wallet/wallet_internal_test.go
+++ b/backend/sim/wallet/wallet_internal_test.go
@@ -98,6 +98,6 @@ func newWalletSetup(rng *rand.Rand) *test.Setup {
 	return &test.Setup{
 		Backend:         new(Backend),
 		UnlockedAccount: unlockedAccount,
-		AddressBytes:    accountB.Address().Bytes(),
+		AddressEncoded:  accountB.Address().Bytes(),
 	}
 }

--- a/wallet/address.go
+++ b/wallet/address.go
@@ -27,7 +27,8 @@ import (
 // Address represents a identifier used in a cryptocurrency.
 // It is dependent on the currency and needs to be implemented for every blockchain.
 type Address interface {
-	io.Serializer
+	// Encoder should write an address that can be decoded with Backend.DecodeAddress.
+	io.Encoder
 	// Bytes should return the representation of the address as byte slice.
 	Bytes() []byte
 	// String converts this address to a string.

--- a/wallet/backend.go
+++ b/wallet/backend.go
@@ -24,7 +24,7 @@ var backend Backend
 
 // Backend provides useful methods for this blockchain.
 type Backend interface {
-	// DecodeAddress reads and decodes an address from an io.Writer
+	// DecodeAddress should read an address that was encoded with Address.Encode.
 	DecodeAddress(io.Reader) (Address, error)
 
 	// DecodeSig reads a signature from the provided stream. It is needed for

--- a/wallet/test/walletbench.go
+++ b/wallet/test/walletbench.go
@@ -67,7 +67,7 @@ func benchBackendVerifySig(b *testing.B, s *Setup) {
 
 func benchBackendDecodeAddress(b *testing.B, s *Setup) {
 	for n := 0; n < b.N; n++ {
-		_, err := s.Backend.DecodeAddress(bytes.NewReader(s.AddressBytes))
+		_, err := s.Backend.DecodeAddress(bytes.NewReader(s.AddressEncoded))
 
 		if err != nil {
 			b.Fatal(err)

--- a/wallet/test/wallettest.go
+++ b/wallet/test/wallettest.go
@@ -136,7 +136,6 @@ func GenericAddressTest(t *testing.T, s *Setup) {
 	assert.Greater(t, len(addrString), 0)
 	assert.NotEqual(t, addrString, nullString)
 
-	assert.Equal(t, s.AddressEncoded, addr.Bytes(), "Expected equality of address bytes")
 	assert.False(t, addr.Equals(null), "Expected inequality of zero, nonzero address")
 	assert.True(t, null.Equals(null), "Expected equality of zero address to itself")
 

--- a/wallet/test/wallettest.go
+++ b/wallet/test/wallettest.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"perun.network/go-perun/pkg/io"
-	"perun.network/go-perun/pkg/io/test"
 	"perun.network/go-perun/wallet"
 )
 
@@ -139,9 +138,6 @@ func GenericAddressTest(t *testing.T, s *Setup) {
 	assert.False(t, addr.Equals(null), "Expected inequality of zero, nonzero address")
 	assert.True(t, null.Equals(null), "Expected equality of zero address to itself")
 
-	t.Run("Generic Serializer Test", func(t *testing.T) {
-		test.GenericSerializerTest(t, addr)
-	})
 	// a.Equals(Decode(Encode(a)))
 	t.Run("Serialize Equals Test", func(t *testing.T) {
 		buff := new(bytes.Buffer)

--- a/wallet/test/wallettest.go
+++ b/wallet/test/wallettest.go
@@ -35,8 +35,8 @@ type UnlockedAccount func() (wallet.Account, error)
 type Setup struct {
 	UnlockedAccount UnlockedAccount // provides an account that is ready to sign
 	// Address tests
-	AddressBytes []byte         // a valid nonzero address not in the wallet
-	Backend      wallet.Backend // backend implementation
+	AddressEncoded []byte         // a valid nonzero address not in the wallet
+	Backend        wallet.Backend // backend implementation
 	// Signature tests
 	DataToSign []byte
 }
@@ -53,7 +53,7 @@ func GenericSignatureTest(t *testing.T, s *Setup) {
 	assert.True(t, valid, "Verification should succeed")
 	assert.NoError(t, err, "Verification should not produce error")
 
-	addr, err := s.Backend.DecodeAddress(bytes.NewBuffer(s.AddressBytes))
+	addr, err := s.Backend.DecodeAddress(bytes.NewBuffer(s.AddressEncoded))
 	assert.NoError(t, err, "Byte deserialization of address should work")
 	valid, err = s.Backend.VerifySignature(s.DataToSign, sign, addr)
 	assert.False(t, valid, "Verification with wrong address should fail")
@@ -124,10 +124,10 @@ func GenericSignatureSizeTest(t *testing.T, s *Setup) {
 // GenericAddressTest runs a test suite designed to test the general functionality of addresses.
 // This function should be called by every implementation of the wallet interface.
 func GenericAddressTest(t *testing.T, s *Setup) {
-	addrLen := len(s.AddressBytes)
+	addrLen := len(s.AddressEncoded)
 	null, err := s.Backend.DecodeAddress(bytes.NewReader(make([]byte, addrLen)))
 	assert.NoError(t, err, "Byte deserialization of zero address should work")
-	addr, err := s.Backend.DecodeAddress(bytes.NewReader(s.AddressBytes))
+	addr, err := s.Backend.DecodeAddress(bytes.NewReader(s.AddressEncoded))
 	assert.NoError(t, err, "Byte deserialization of address should work")
 
 	nullString := null.String()
@@ -136,7 +136,7 @@ func GenericAddressTest(t *testing.T, s *Setup) {
 	assert.Greater(t, len(addrString), 0)
 	assert.NotEqual(t, addrString, nullString)
 
-	assert.Equal(t, s.AddressBytes, addr.Bytes(), "Expected equality of address bytes")
+	assert.Equal(t, s.AddressEncoded, addr.Bytes(), "Expected equality of address bytes")
 	assert.False(t, addr.Equals(null), "Expected inequality of zero, nonzero address")
 	assert.True(t, null.Equals(null), "Expected equality of zero address to itself")
 


### PR DESCRIPTION
Closes #193 

The variable name was suggesting that it can always be initialized with `Address.Bytes`, but the tests were assuming that the address is decodable, which is not necessarily true for `Address.Bytes`. In particular, note that the length of `Address.Bytes` can be retrieved using the `len` operator, while the length of an encoded address must either be known in advance or contained in the encoding.