### PR TITLE
balance reader interface

### DIFF
--- a/backend/ethereum/client/dispute_test.go
+++ b/backend/ethereum/client/dispute_test.go
@@ -18,23 +18,19 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"perun.network/go-perun/backend/ethereum/channel/test"
+	ctest "perun.network/go-perun/backend/ethereum/client/test"
 	"perun.network/go-perun/backend/ethereum/wallet"
 	"perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
 	"perun.network/go-perun/log"
 	pkgtest "perun.network/go-perun/pkg/test"
 	"perun.network/go-perun/wire"
-)
-
-const (
-	blockInterval = 100 * time.Millisecond
 )
 
 func TestDisputeMalloryCarol(t *testing.T) {
@@ -48,8 +44,8 @@ func TestDisputeMalloryCarol(t *testing.T) {
 		role  [2]clienttest.Executer
 	)
 
-	s := test.NewSetup(t, rng, 2, blockInterval)
-	setup = makeRoleSetups(s, name)
+	s := test.NewSetup(t, rng, 2, ctest.BlockInterval)
+	setup = ctest.MakeRoleSetups(s, name)
 
 	role[A] = clienttest.NewMallory(setup[A], t)
 	role[B] = clienttest.NewCarol(setup[B], t)
@@ -74,7 +70,7 @@ func TestDisputeMalloryCarol(t *testing.T) {
 		new(big.Int).Sub(execConfig.InitBals()[A], netTransfer),
 		new(big.Int).Add(execConfig.InitBals()[B], netTransfer)}
 	// reset context timeout
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), ctest.DefaultTimeout)
 	defer cancel()
 	for i, bal := range finalBal {
 		b, err := s.SimBackend.BalanceAt(ctx, common.Address(*s.Recvs[i]), nil)

--- a/backend/ethereum/client/happy_test.go
+++ b/backend/ethereum/client/happy_test.go
@@ -19,13 +19,13 @@ import (
 	"math/big"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"perun.network/go-perun/backend/ethereum/channel/test"
+	ctest "perun.network/go-perun/backend/ethereum/client/test"
 	"perun.network/go-perun/backend/ethereum/wallet"
 	chtest "perun.network/go-perun/channel/test"
 	perunclient "perun.network/go-perun/client"
@@ -34,8 +34,6 @@ import (
 	pkgtest "perun.network/go-perun/pkg/test"
 	"perun.network/go-perun/wire"
 )
-
-var defaultTimeout = 5 * time.Second
 
 func TestHappyAliceBob(t *testing.T) {
 	log.Info("Starting happy test")
@@ -48,8 +46,8 @@ func TestHappyAliceBob(t *testing.T) {
 		role  [2]clienttest.Executer
 	)
 
-	s := test.NewSetup(t, rng, 2, blockInterval)
-	setup = makeRoleSetups(s, name)
+	s := test.NewSetup(t, rng, 2, ctest.BlockInterval)
+	setup = ctest.MakeRoleSetups(s, name)
 
 	role[A] = clienttest.NewAlice(setup[A], t)
 	role[B] = clienttest.NewBob(setup[B], t)
@@ -86,7 +84,7 @@ func TestHappyAliceBob(t *testing.T) {
 	finalBalAlice := new(big.Int).Sub(execConfig.InitBals()[A], aliceToBob)
 	finalBalBob := new(big.Int).Add(execConfig.InitBals()[B], aliceToBob)
 	// reset context timeout
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), ctest.DefaultTimeout)
 	defer cancel()
 	assertBal := func(addr *wallet.Address, bal *big.Int) {
 		b, err := s.SimBackend.BalanceAt(ctx, common.Address(*addr), nil)

--- a/backend/ethereum/client/test/doc.go
+++ b/backend/ethereum/client/test/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2021 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test contains utilities for running client tests for Ethereum.
+package test // import "perun.network/go-perun/backend/ethereum/client/test"

--- a/backend/ethereum/client/test/setup.go
+++ b/backend/ethereum/client/test/setup.go
@@ -1,0 +1,46 @@
+// Copyright 2021 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"time"
+
+	ethctest "perun.network/go-perun/backend/ethereum/channel/test"
+	ethwtest "perun.network/go-perun/backend/ethereum/wallet/test"
+	clienttest "perun.network/go-perun/client/test"
+	"perun.network/go-perun/wire"
+)
+
+const (
+	DefaultTimeout = 5 * time.Second
+	BlockInterval  = 100 * time.Millisecond
+)
+
+func MakeRoleSetups(s *ethctest.Setup, names [2]string) (setup [2]clienttest.RoleSetup) {
+	bus := wire.NewLocalBus()
+	for i := 0; i < len(setup); i++ {
+		setup[i] = clienttest.RoleSetup{
+			Name:              names[i],
+			Identity:          s.Accs[i],
+			Bus:               bus,
+			Funder:            s.Funders[i],
+			Adjudicator:       s.Adjs[i],
+			Wallet:            ethwtest.NewTmpWallet(),
+			Timeout:           DefaultTimeout,
+			ChallengeDuration: 60 * uint64(time.Second/BlockInterval), // Scaled due to simbackend automining progressing faster than real time.
+		}
+	}
+	return
+}

--- a/client/client_role_test.go
+++ b/client/client_role_test.go
@@ -45,7 +45,7 @@ func NewSetups(rng *rand.Rand, names []string) []ctest.RoleSetup {
 			Adjudicator:       backend,
 			Wallet:            wtest.NewWallet(),
 			Timeout:           roleOperationTimeout,
-			Backend:           backend,
+			BalanceReader:     backend,
 			ChallengeDuration: 60,
 		}
 	}

--- a/client/test/backend.go
+++ b/client/test/backend.go
@@ -209,12 +209,12 @@ func (b *MockBackend) isConcluded(ch channel.ID) bool {
 }
 
 func (b *MockBackend) addBalance(p wallet.Address, a channel.Asset, v *big.Int) {
-	bal := b.getBalance(p, a)
+	bal := b.balance(p, a)
 	bal = new(big.Int).Add(bal, v)
 	b.setBalance(p, a, bal)
 }
 
-func (b *MockBackend) getBalance(p wallet.Address, a channel.Asset) *big.Int {
+func (b *MockBackend) balance(p wallet.Address, a channel.Asset) *big.Int {
 	partBals, ok := b.balances[newAddressMapKey(p)]
 	if !ok {
 		return big.NewInt(0)
@@ -247,11 +247,11 @@ func encodableAsString(e io.Encoder) string {
 	return buf.String()
 }
 
-// GetBalance returns the balance for the participant and asset.
-func (b *MockBackend) GetBalance(p wallet.Address, a channel.Asset) *big.Int {
+// Balance returns the balance for the participant and asset.
+func (b *MockBackend) Balance(p wallet.Address, a channel.Asset) *big.Int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.getBalance(p, a)
+	return b.balance(p, a)
 }
 
 func (b *MockBackend) setBalance(p wallet.Address, a channel.Asset, v *big.Int) {

--- a/client/test/role.go
+++ b/client/test/role.go
@@ -29,6 +29,7 @@ import (
 	"perun.network/go-perun/channel/persistence"
 	"perun.network/go-perun/client"
 	"perun.network/go-perun/log"
+	"perun.network/go-perun/wallet"
 	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 )
@@ -54,6 +55,11 @@ type (
 		sync.RWMutex
 	}
 
+	// BalanceReader can be used to read state from a ledger.
+	BalanceReader interface {
+		Balance(p wallet.Address, a channel.Asset) channel.Bal
+	}
+
 	// RoleSetup contains the injectables for setting up the client.
 	RoleSetup struct {
 		Name              string
@@ -64,7 +70,7 @@ type (
 		Wallet            wallettest.Wallet
 		PR                persistence.PersistRestorer // Optional PersistRestorer
 		Timeout           time.Duration               // Timeout waiting for other role, not challenge duration
-		Backend           *MockBackend
+		BalanceReader     BalanceReader
 		ChallengeDuration uint64
 	}
 

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -98,12 +98,12 @@ func TestVirtualChannelsDispute(t *testing.T) {
 
 func (vct *virtualChannelTest) testFinalBalancesDispute(t *testing.T) {
 	assert := assert.New(t)
-	backend, asset := vct.backend, vct.asset
-	got, expected := backend.GetBalance(vct.alice.Identity.Address(), asset), vct.finalBalsAlice[0]
+	backend, asset := vct.balanceReader, vct.asset
+	got, expected := backend.Balance(vct.alice.Identity.Address(), asset), vct.finalBalsAlice[0]
 	assert.Truef(got.Cmp(expected) == 0, "alice: wrong final balance: got %v, expected %v", got, expected)
-	got, expected = backend.GetBalance(vct.bob.Identity.Address(), asset), vct.finalBalsBob[0]
+	got, expected = backend.Balance(vct.bob.Identity.Address(), asset), vct.finalBalsBob[0]
 	assert.Truef(got.Cmp(expected) == 0, "bob: wrong final balance: got %v, expected %v", got, expected)
-	got, expected = backend.GetBalance(vct.ingrid.Identity.Address(), asset), vct.finalBalIngrid
+	got, expected = backend.Balance(vct.ingrid.Identity.Address(), asset), vct.finalBalIngrid
 	assert.Truef(got.Cmp(expected) == 0, "ingrid: wrong final balance: got %v, expected %v", got, expected)
 }
 
@@ -122,7 +122,7 @@ type virtualChannelTest struct {
 	finalBalsBob       []*big.Int
 	finalBalIngrid     *big.Int
 	errs               chan error
-	backend            *ctest.MockBackend
+	balanceReader      ctest.BalanceReader
 	asset              channel.Asset
 }
 
@@ -150,7 +150,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	)
 	alice, bob, ingrid := clients[0], clients[1], clients[2]
 	vct.alice, vct.bob, vct.ingrid = alice, bob, ingrid
-	vct.backend = alice.Backend // Assumes all clients have same backend.
+	vct.balanceReader = alice.BalanceReader // Assumes all clients have same backend.
 
 	_channelsIngrid := make(chan *client.Channel, 1)
 	var openingProposalHandlerIngrid client.ProposalHandlerFunc = func(cp client.ChannelProposal, pr *client.ProposalResponder) {


### PR DESCRIPTION
Closes #200 

Introduces a balance reader interface for the generic client tests.

(Also moves `func makeRoleSetups` to a more suitable location.)