### PR TITLE
207 fix ensure registered

### DIFF
--- a/backend/ethereum/channel/conclude_test.go
+++ b/backend/ethereum/channel/conclude_test.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	defaultTestTimeout = 10 * time.Second
-	blockInterval      = 100 * time.Millisecond
+	blockInterval      = 10 * time.Millisecond
 )
 
 func TestAdjudicator_ConcludeFinal(t *testing.T) {


### PR DESCRIPTION
Closes #207 
Closes #206 

Also fixes another issue where `ensureRegistered` would fail because the channel is registered twice.