### PR TITLE
backend/eth/channel: Fix state app decoding

### DIFF
--- a/backend/ethereum/channel/backend.go
+++ b/backend/ethereum/channel/backend.go
@@ -263,6 +263,7 @@ func FromEthState(app channel.App, s *adjudicator.ChannelState) channel.State {
 		ID:         s.ChannelID,
 		Version:    s.Version,
 		Allocation: alloc,
+		App:        app,
 		Data:       data,
 		IsFinal:    s.IsFinal,
 	}


### PR DESCRIPTION
Function `FromEthState` did not set the App correctly on a decoded state.

Relates to #226 