### PR TITLE
Context check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
     # These could be enabled in the future:
     - ifshort # we often don't use `if err := …` for readability.
     - tparallel # We don't always use parallel tests.
-    - contextcheck # Wants contexts to be always passed down.
 
     # Deprecated:
     - maligned
@@ -64,6 +63,8 @@ issues:
         - forcetypeassert
         # Can create dynamic errors with errors.New.
         - goerr113
+        # Can derive contexts from context.Background() in nested calls.
+        - contextcheck
 
     # We always use testing.T as first argument in testing functions,
     # therefore disable the "context must be the first argument" check in tests.

--- a/backend/ethereum/channel/test/adjudicator.go
+++ b/backend/ethereum/channel/test/adjudicator.go
@@ -121,7 +121,7 @@ func (t *SimTimeout) IsElapsed(ctx context.Context) bool {
 	}
 	defer t.sb.clockMu.Unlock()
 
-	return t.timeLeft() <= 0
+	return t.timeLeft(ctx) <= 0
 }
 
 // Wait advances the clock of the simulated blockchain past the timeout.
@@ -132,7 +132,7 @@ func (t *SimTimeout) Wait(ctx context.Context) error {
 	}
 	defer t.sb.clockMu.Unlock()
 
-	if d := t.timeLeft(); d > 0 {
+	if d := t.timeLeft(ctx); d > 0 {
 		if err := t.sb.AdjustTime(time.Duration(d) * time.Second); err != nil {
 			return errors.Wrap(err, "adjusting time")
 		}
@@ -141,10 +141,10 @@ func (t *SimTimeout) Wait(ctx context.Context) error {
 	return nil
 }
 
-func (t *SimTimeout) timeLeft() int64 {
+func (t *SimTimeout) timeLeft(ctx context.Context) int64 {
 	// context is ignored by sim blockchain anyways
-	h, err := t.sb.HeaderByNumber(nil, nil) //nolint:staticcheck
-	if err != nil {                         // should never happen with a sim blockchain
+	h, err := t.sb.HeaderByNumber(ctx, nil)
+	if err != nil { // should never happen with a sim blockchain
 		panic(fmt.Sprint("Error getting latest block: ", err))
 	}
 	return int64(t.Time) - int64(h.Time)

--- a/client/channelconn.go
+++ b/client/channelconn.go
@@ -44,9 +44,7 @@ type channelConn struct {
 // subscribes on the subscriber to all messages regarding this channel.
 func newChannelConn(id channel.ID, peers []wire.Address, idx channel.Index, sub wire.Subscriber, pub wire.Publisher) (_ *channelConn, err error) {
 	// relay to receive all update responses
-	relay := wire.NewRelay()
-	// we cache all responses for the lifetime of the relay
-	relay.Cache(context.Background(), func(*wire.Envelope) bool { return true })
+	relay := wire.NewRelayNeverForget()
 	// Close the relay if anything goes wrong in the following.
 	// We could have a leaky subscription otherwise.
 	defer func() {

--- a/wire/relay.go
+++ b/wire/relay.go
@@ -44,6 +44,15 @@ func NewRelay() *Relay {
 	return &Relay{defaultMsgHandler: logUnhandledMsg}
 }
 
+// NewRelayNeverForget returns a new Relay which caches all messages
+// until it is closed.
+func NewRelayNeverForget() *Relay {
+	relay := NewRelay()
+	relay.Cache(context.Background(), func(*Envelope) bool { return true })
+
+	return relay
+}
+
 // Close closes the relay.
 func (p *Relay) Close() error {
 	if err := p.Closer.Close(); err != nil {


### PR DESCRIPTION
- Introduces `wire.NewRelayNeverForget()` to remove a context check error
- Fixes one contextcheck error and removes a `nolint:staticcheck`
- Enables contextcheck for non-testing code

The remaining linter warnings in the CI need to be discussed.  
As far as i understand this, it wants us to introduce a context in `Client.Handle` and pass it down to the handlers, aka `handleChannelUpdate`.  
Currently the timeout for the handlers are derived from `client.Ctx` so there could be requests which run until the client is closed.  
We could add some timeouts like `channelUpdateTimeout` akin to `virtualFundingTimeout` and use them in `client.Handle`.  

What do you think?  
@matthiasgeihs 