### PR TITLE
[sim] Use all bytes for Addr.String()

### DIFF
--- a/backend/sim/wallet/address.go
+++ b/backend/sim/wallet/address.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/ecdsa"
-	"encoding/hex"
+	"fmt"
 	"io"
 	"math/big"
 
@@ -87,15 +87,7 @@ func (a *Address) ByteArray() (data [AddrLen]byte) {
 
 // String converts this address to a human-readable string.
 func (a *Address) String() string {
-	const length = 4
-	// Encode the address directly instead of using Address.Bytes() because
-	// * some addresses may have a very short encoding, e.g., the null address,
-	// * the Address.Bytes() output may contain encoding information, e.g., the
-	//   length.
-	bs := make([]byte, length)
-	copy(bs, a.X.Bytes())
-
-	return "0x" + hex.EncodeToString(bs)
+	return fmt.Sprintf("0x%x", a.ByteArray())
 }
 
 // Equal checks the equality of two addresses. The implementation must be

--- a/backend/sim/wallet/wallet_internal_test.go
+++ b/backend/sim/wallet/wallet_internal_test.go
@@ -78,12 +78,13 @@ func TestGenericTests(t *testing.T) {
 		assert.NotEqual(
 			t, addr0, addr1, "Two random accounts should not be the same")
 
+		addrStrLen := AddrLen*2 + 2 // hex encoded and prefixed with 0x
 		str0 := addr0.String()
 		str1 := addr1.String()
 		assert.Equal(
-			t, 10, len(str0), "First address '%v' has wrong length", str0)
+			t, addrStrLen, len(str0), "First address '%v' has wrong length", str0)
 		assert.Equal(
-			t, 10, len(str1), "Second address '%v' has wrong length", str1)
+			t, addrStrLen, len(str1), "Second address '%v' has wrong length", str1)
 		assert.NotEqual(
 			t, str0, str1, "Printed addresses are unlikely to be identical")
 	}


### PR DESCRIPTION
- Don't discard bytes anymore when encoding a sim address.  

Closes #261