### PR TITLE
:truck: [MIGRATION] Use pkg/io instead of poly-go/io

### DIFF
--- a/backend/ethereum/channel/backend_test.go
+++ b/backend/ethereum/channel/backend_test.go
@@ -31,9 +31,9 @@ import (
 	ethwallettest "perun.network/go-perun/backend/ethereum/wallet/test"
 	perunchannel "perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
+	iotest "perun.network/go-perun/pkg/io/test"
 	perunwallet "perun.network/go-perun/wallet"
 	wallettest "perun.network/go-perun/wallet/test"
-	iotest "polycry.pt/poly-go/io/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/backend/ethereum/wallet/backend.go
+++ b/backend/ethereum/wallet/backend.go
@@ -20,8 +20,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 // Backend implements the utility interface defined in the wallet package.

--- a/backend/sim/channel/backend.go
+++ b/backend/sim/channel/backend.go
@@ -23,8 +23,8 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/log"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 // backend implements the utility interface defined in the channel package.

--- a/backend/sim/wallet/address.go
+++ b/backend/sim/wallet/address.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 
 	"perun.network/go-perun/log"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 // Address represents a simulated address.

--- a/backend/sim/wallet/backend.go
+++ b/backend/sim/wallet/backend.go
@@ -23,8 +23,8 @@ import (
 	"github.com/pkg/errors"
 
 	"perun.network/go-perun/log"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 var curve = elliptic.P256()

--- a/channel/allocation.go
+++ b/channel/allocation.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"math/big"
 
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 	perunbig "polycry.pt/poly-go/math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"

--- a/channel/allocation_test.go
+++ b/channel/allocation_test.go
@@ -24,8 +24,8 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
-	perunio "polycry.pt/poly-go/io"
-	iotest "polycry.pt/poly-go/io/test"
+	perunio "perun.network/go-perun/pkg/io"
+	iotest "perun.network/go-perun/pkg/io/test"
 	pkgbig "polycry.pt/poly-go/math/big"
 	pkgtest "polycry.pt/poly-go/test"
 )

--- a/channel/app.go
+++ b/channel/app.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 type (

--- a/channel/machine.go
+++ b/channel/machine.go
@@ -21,8 +21,8 @@ import (
 	"github.com/pkg/errors"
 
 	"perun.network/go-perun/log"
+	"perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	"polycry.pt/poly-go/io"
 	"polycry.pt/poly-go/math/big"
 )
 

--- a/channel/mock_app.go
+++ b/channel/mock_app.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 // MockApp a mocked App whose behaviour is determined by the MockOp passed to it either as State.Data or Action.

--- a/channel/mock_app_internal_test.go
+++ b/channel/mock_app_internal_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	iotest "perun.network/go-perun/pkg/io/test"
 	wallettest "perun.network/go-perun/wallet/test"
-	iotest "polycry.pt/poly-go/io/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/channel/params.go
+++ b/channel/params.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pkg/errors"
 
 	"perun.network/go-perun/log"
+	"perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	"polycry.pt/poly-go/io"
 )
 
 // IDLen the length of a channelID.

--- a/channel/params_test.go
+++ b/channel/params_test.go
@@ -19,8 +19,8 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
-	"polycry.pt/poly-go/io"
-	iotest "polycry.pt/poly-go/io/test"
+	"perun.network/go-perun/pkg/io"
+	iotest "perun.network/go-perun/pkg/io/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/channel/persistence/keyvalue/persistedstate.go
+++ b/channel/persistence/keyvalue/persistedstate.go
@@ -18,7 +18,7 @@ import (
 	"io"
 
 	"perun.network/go-perun/channel"
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 )
 
 var (

--- a/channel/persistence/keyvalue/persister.go
+++ b/channel/persistence/keyvalue/persister.go
@@ -26,8 +26,8 @@ import (
 	"github.com/pkg/errors"
 
 	"perun.network/go-perun/channel"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wire"
-	perunio "polycry.pt/poly-go/io"
 	"polycry.pt/poly-go/sortedkv"
 )
 

--- a/channel/persistence/keyvalue/restorer.go
+++ b/channel/persistence/keyvalue/restorer.go
@@ -24,9 +24,9 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/persistence"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
-	perunio "polycry.pt/poly-go/io"
 	"polycry.pt/poly-go/sortedkv"
 )
 

--- a/channel/state.go
+++ b/channel/state.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 )
 
 type (

--- a/channel/state_test.go
+++ b/channel/state_test.go
@@ -20,7 +20,7 @@ import (
 	_ "perun.network/go-perun/backend/sim" // backend init
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
-	iotest "polycry.pt/poly-go/io/test"
+	iotest "perun.network/go-perun/pkg/io/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/channel/transaction.go
+++ b/channel/transaction.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	perunio "polycry.pt/poly-go/io"
 )
 
 // Transaction is a channel state together with valid signatures from the

--- a/channel/transaction_test.go
+++ b/channel/transaction_test.go
@@ -19,7 +19,7 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
-	iotest "polycry.pt/poly-go/io/test"
+	iotest "perun.network/go-perun/pkg/io/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/client/proposal.go
+++ b/client/proposal.go
@@ -24,10 +24,10 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/log"
+	"perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
 	pcontext "polycry.pt/poly-go/context"
-	"polycry.pt/poly-go/io"
 	"polycry.pt/poly-go/sync/atomic"
 )
 

--- a/client/proposalmsgs.go
+++ b/client/proposalmsgs.go
@@ -24,9 +24,9 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/log"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
-	perunio "polycry.pt/poly-go/io"
 	perunbig "polycry.pt/poly-go/math/big"
 )
 

--- a/client/serialize.go
+++ b/client/serialize.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"perun.network/go-perun/channel"
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 )
 
 type (

--- a/client/syncmsgs.go
+++ b/client/syncmsgs.go
@@ -18,8 +18,8 @@ import (
 	"io"
 
 	"perun.network/go-perun/channel"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wire"
-	perunio "polycry.pt/poly-go/io"
 )
 
 func init() {

--- a/client/test/backend.go
+++ b/client/test/backend.go
@@ -25,8 +25,8 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/log"
+	"perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	"polycry.pt/poly-go/io"
 )
 
 type (

--- a/client/updatemsgs.go
+++ b/client/updatemsgs.go
@@ -18,9 +18,9 @@ import (
 	"io"
 
 	"perun.network/go-perun/channel"
+	perunio "perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
-	perunio "polycry.pt/poly-go/io"
 )
 
 func init() {

--- a/pkg/io/bigint.go
+++ b/pkg/io/bigint.go
@@ -1,0 +1,86 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/pkg/errors"
+)
+
+// MaxBigIntLength defines the maximum length of a big integer.
+// 1024bit -> 128 bytes.
+const MaxBigIntLength = 128
+
+// BigInt is a serializer big integer.
+type BigInt struct {
+	*big.Int
+}
+
+// Decode reads a big.Int from the given stream.
+func (b *BigInt) Decode(reader io.Reader) error {
+	// Read length
+	lengthData := make([]byte, 1)
+	if _, err := reader.Read(lengthData); err != nil {
+		return errors.Wrap(err, "failed to decode length of big.Int")
+	}
+
+	length := lengthData[0]
+	if length > MaxBigIntLength {
+		return errors.New("big.Int too big to decode")
+	}
+
+	bytes := make([]byte, length)
+	if n, err := io.ReadFull(reader, bytes); err != nil {
+		return errors.Wrapf(err, "failed to read bytes for big.Int, read %d/%d", n, length)
+	}
+
+	if b.Int == nil {
+		b.Int = new(big.Int)
+	}
+	b.Int.SetBytes(bytes)
+	return nil
+}
+
+// Encode writes a big.Int to the stream.
+func (b BigInt) Encode(writer io.Writer) error {
+	if b.Int == nil {
+		panic("logic error: tried to encode nil big.Int")
+	}
+	if b.Int.Sign() == -1 {
+		panic("encoding of negative big.Int not implemented")
+	}
+
+	bytes := b.Bytes()
+	length := len(bytes)
+	// we serialize the length as uint8
+	if length > MaxBigIntLength {
+		return errors.New("big.Int too big to encode")
+	}
+
+	// Write length
+	if _, err := writer.Write([]byte{uint8(length)}); err != nil {
+		return errors.Wrap(err, "failed to write length")
+	}
+
+	if length == 0 {
+		return nil
+	}
+
+	// Write bytes
+	n, err := writer.Write(bytes)
+	return errors.Wrapf(err, "failed to write big.Int, wrote %d bytes of %d", n, length)
+}

--- a/pkg/io/bigint_external_test.go
+++ b/pkg/io/bigint_external_test.go
@@ -1,0 +1,89 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io_test
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	polyio "polycry.pt/poly-go/io"
+	"polycry.pt/poly-go/io/test"
+)
+
+func TestBigInt_Generic(t *testing.T) {
+	vars := []polyio.Serializer{
+		&polyio.BigInt{Int: big.NewInt(0)},
+		&polyio.BigInt{Int: big.NewInt(1)},
+		&polyio.BigInt{Int: big.NewInt(123456)},
+		&polyio.BigInt{Int: new(big.Int).SetBytes([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}, // larger than uint64
+	}
+	test.GenericSerializerTest(t, vars...)
+}
+
+func TestBigInt_DecodeZeroLength(t *testing.T) {
+	assert := assert.New(t)
+
+	buf := bytes.NewBuffer([]byte{0})
+	var result polyio.BigInt
+	assert.NoError(result.Decode(buf), "decoding zero length big.Int should work")
+	assert.Zero(new(big.Int).Cmp(result.Int), "decoding zero length should set big.Int to 0")
+}
+
+func TestBigInt_DecodeToExisting(t *testing.T) {
+	x, buf := new(big.Int), bytes.NewBuffer([]byte{1, 42})
+	wx := polyio.BigInt{Int: x}
+	assert.NoError(t, wx.Decode(buf), "decoding {1, 42} into big.Int should work")
+	assert.Zero(t, big.NewInt(42).Cmp(x), "decoding {1, 42} into big.Int should result in 42")
+}
+
+func TestBigInt_Negative(t *testing.T) {
+	neg, buf := polyio.BigInt{Int: big.NewInt(-1)}, new(bytes.Buffer)
+	assert.Panics(t, func() { _ = neg.Encode(buf) }, "encoding negative big.Int should panic")
+	assert.Zero(t, buf.Len(), "encoding negative big.Int should not write anything")
+}
+
+func TestBigInt_Invalid(t *testing.T) {
+	a := assert.New(t)
+	buf := new(bytes.Buffer)
+	// Test integers that are too big
+	tooBigBitPos := []uint{polyio.MaxBigIntLength*8 + 1, 0xff*8 + 1} // too big uint8 and uint16 lengths
+	for _, pos := range tooBigBitPos {
+		tooBig := polyio.BigInt{Int: big.NewInt(1)}
+		tooBig.Lsh(tooBig.Int, pos)
+
+		a.Error(tooBig.Encode(buf), "encoding too big big.Int should fail")
+		a.Zero(buf.Len(), "encoding too big big.Int should not have written anything")
+		buf.Reset() // in case above test failed
+	}
+
+	// manually encode too big number to test failing of decoding
+	buf.Write([]byte{polyio.MaxBigIntLength + 1})
+	for i := 0; i < polyio.MaxBigIntLength+1; i++ {
+		buf.WriteByte(0xff)
+	}
+
+	var result polyio.BigInt
+	a.Error(result.Decode(buf), "decoding of an integer that is too big should fail")
+	buf.Reset()
+
+	// Test not sending value, only length
+	buf.WriteByte(1)
+	a.Error(result.Decode(buf), "decoding after sender only sent length should fail")
+
+	a.Panics(func() { _ = polyio.BigInt{Int: nil}.Encode(buf) }, "encoding nil big.Int failed to panic")
+}

--- a/pkg/io/byteslice.go
+++ b/pkg/io/byteslice.go
@@ -1,0 +1,48 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// ByteSlice is a serializer byte slice.
+type ByteSlice []byte
+
+var _ Serializer = (*ByteSlice)(nil)
+
+// Encode writes len(b) bytes to the stream. Note that the length itself is not
+// written to the stream.
+func (b ByteSlice) Encode(w io.Writer) error {
+	_, err := w.Write(b)
+	return errors.Wrap(err, "failed to write []byte")
+}
+
+// Decode reads a byte slice from the given stream.
+// Decode reads exactly len(b) bytes.
+// This means the caller has to specify how many bytes he wants to read.
+func (b *ByteSlice) Decode(r io.Reader) error {
+	// This is almost the same as io.ReadFull, but it also fails on closed
+	// readers.
+	n, err := r.Read(*b)
+	for n < len(*b) && err == nil {
+		var nn int
+		nn, err = r.Read((*b)[n:])
+		n += nn
+	}
+	return errors.Wrap(err, "failed to read []byte")
+}

--- a/pkg/io/byteslice_external_test.go
+++ b/pkg/io/byteslice_external_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io_test
+
+import (
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ctxtest "polycry.pt/poly-go/context/test"
+	polyio "polycry.pt/poly-go/io"
+	iotest "polycry.pt/poly-go/io/test"
+)
+
+func TestByteSlice(t *testing.T) {
+	var v1, v2, v3, v4 polyio.ByteSlice = []byte{}, []byte{255}, []byte{1, 2, 3, 4, 5, 6}, make([]byte, 20000)
+	testByteSlices(t, v1, v2, v3, v4)
+	iotest.GenericBrokenPipeTest(t, &v1, &v2, &v3, &v4)
+}
+
+// TestStutter tests what happens if the network stutters (split one message into several network packages).
+func TestStutter(t *testing.T) {
+	values := []byte{0, 1, 2, 3, 4, 5, 6, 255}
+	r, w := io.Pipe()
+
+	go func() {
+		for _, v := range values {
+			_, err := w.Write([]byte{v})
+			assert.NoError(t, err)
+		}
+	}()
+
+	var decodedValue polyio.ByteSlice = make([]byte, len(values))
+	ctxtest.AssertTerminatesQuickly(t, func() {
+		assert.NoError(t, decodedValue.Decode(r))
+	})
+	for i, v := range values {
+		assert.Equal(t, decodedValue[i], v)
+	}
+}
+
+func testByteSlices(t *testing.T, serial ...polyio.ByteSlice) {
+	t.Helper()
+	a := assert.New(t)
+	r, w := io.Pipe()
+	done := make(chan struct{})
+
+	go func() {
+		for _, v := range serial {
+			a.NoError(v.Encode(w))
+		}
+		close(done)
+	}()
+
+	for i, v := range serial {
+		d := make([]byte, len(v))
+		dest := polyio.ByteSlice(d)
+
+		a.NoError(dest.Decode(r), "failed to decode element")
+
+		if !reflect.DeepEqual(v, dest) {
+			t.Errorf("encoding and decoding the %dth element (%T) resulted in different value: %v, %v", i, v, reflect.ValueOf(v).Elem(), dest)
+		}
+	}
+	<-done
+}

--- a/pkg/io/doc.go
+++ b/pkg/io/doc.go
@@ -12,29 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wire
-
-import (
-	"io"
-	"testing"
-
-	"perun.network/go-perun/pkg/io/test"
-)
-
-type serializerMsg struct {
-	Msg Msg
-}
-
-func (msg *serializerMsg) Encode(writer io.Writer) error {
-	return Encode(msg.Msg, writer)
-}
-
-func (msg *serializerMsg) Decode(reader io.Reader) (err error) {
-	msg.Msg, err = Decode(reader)
-	return err
-}
-
-// TestMsg performs generic tests on a wire.Msg object.
-func TestMsg(t *testing.T, msg Msg) {
-	test.GenericSerializerTest(t, &serializerMsg{msg})
-}
+// Package io contains functionality for the serialization of standard Go types.
+package io // import "perun.network/go-perun/pkg/io"

--- a/pkg/io/equal_encoding.go
+++ b/pkg/io/equal_encoding.go
@@ -1,0 +1,46 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+)
+
+// EqualEncoding returns whether the two Encoders `a` and `b` encode to the same byteslice
+// or an error when the encoding failed.
+func EqualEncoding(a, b Encoder) (bool, error) {
+	buffA := new(bytes.Buffer)
+	buffB := new(bytes.Buffer)
+
+	// golang does not have a XOR
+	if (a == nil) != (b == nil) {
+		return false, errors.New("only one argument was nil")
+	}
+	// just using a == b would be too easy here since go panics
+	if (a == nil) && (b == nil) {
+		return true, nil
+	}
+
+	if err := a.Encode(buffA); err != nil {
+		return false, errors.Wrap(err, "EqualEncoding encode error")
+	}
+	if err := b.Encode(buffB); err != nil {
+		return false, errors.Wrap(err, "EqualEncoding encode error")
+	}
+
+	return bytes.Equal(buffA.Bytes(), buffB.Bytes()), nil
+}

--- a/pkg/io/equal_encoding_external_test.go
+++ b/pkg/io/equal_encoding_external_test.go
@@ -1,0 +1,71 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"polycry.pt/poly-go/io"
+	polytest "polycry.pt/poly-go/test"
+)
+
+// TestEqualEncoding tests EqualEncoding.
+func TestEqualEncoding(t *testing.T) {
+	rng := polytest.Prng(t)
+	a := make(io.ByteSlice, 10)
+	b := make(io.ByteSlice, 10)
+	c := make(io.ByteSlice, 12)
+
+	rng.Read(a)
+	rng.Read(b)
+	rng.Read(c)
+	c2 := c
+
+	tests := []struct {
+		a         io.Encoder
+		b         io.Encoder
+		shouldOk  bool
+		shouldErr bool
+		name      string
+	}{
+		{a, nil, false, true, "one Encoder set to nil"},
+		{nil, a, false, true, "one Encoder set to nil"},
+		{io.Encoder(nil), b, false, true, "one Encoder set to nil"},
+		{b, io.Encoder(nil), false, true, "one Encoder set to nil"},
+
+		{nil, nil, true, false, "both Encoders set to nil"},
+		{io.Encoder(nil), io.Encoder(nil), true, false, "both Encoders set to nil"},
+
+		{a, a, true, false, "same Encoders"},
+		{a, &a, true, false, "same Encoders"},
+		{&a, a, true, false, "same Encoders"},
+		{&a, &a, true, false, "same Encoders"},
+
+		{c, c2, true, false, "different Encoders and same content"},
+
+		{a, b, false, false, "different Encoders and different content"},
+		{a, c, false, false, "different Encoders and different content"},
+	}
+
+	for _, tt := range tests {
+		ok, err := io.EqualEncoding(tt.a, tt.b)
+
+		assert.Equalf(t, ok, tt.shouldOk, "EqualEncoding with %s should return %t as bool but got: %t", tt.name, tt.shouldOk, ok)
+		assert.Falsef(t, (err == nil) && tt.shouldErr, "EqualEncoding with %s should return an error but got nil", tt.name)
+		assert.Falsef(t, (err != nil) && !tt.shouldErr, "EqualEncoding with %s should return nil as error but got: %s", tt.name, err)
+	}
+}

--- a/pkg/io/serialize.go
+++ b/pkg/io/serialize.go
@@ -1,0 +1,98 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/big"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var byteOrder = binary.LittleEndian
+
+// Encode encodes multiple primitive values into a writer.
+// All passed values must be copies, not references.
+func Encode(writer io.Writer, values ...interface{}) (err error) {
+	for i, value := range values {
+		switch v := value.(type) {
+		case bool, int8, uint8, int16, uint16, int32, uint32, int64, uint64:
+			err = binary.Write(writer, byteOrder, v)
+		case time.Time:
+			err = binary.Write(writer, byteOrder, v.UnixNano())
+		case *big.Int:
+			err = BigInt{v}.Encode(writer)
+		case [32]byte:
+			_, err = writer.Write(v[:])
+		case []byte:
+			err = ByteSlice(v).Encode(writer)
+		case string:
+			err = encodeString(writer, v)
+		default:
+			if enc, ok := value.(Encoder); ok {
+				err = enc.Encode(writer)
+			} else {
+				panic(fmt.Sprintf("polyio.Encode(): Invalid type %T", v))
+			}
+		}
+
+		if err != nil {
+			return errors.WithMessagef(err, "failed to encode %dth value of type %T", i, value)
+		}
+	}
+
+	return nil
+}
+
+// Decode decodes multiple primitive values from a reader.
+// All passed values must be references, not copies.
+func Decode(reader io.Reader, values ...interface{}) (err error) {
+	for i, value := range values {
+		switch v := value.(type) {
+		case *bool, *int8, *uint8, *int16, *uint16, *int32, *uint32, *int64, *uint64:
+			err = binary.Read(reader, byteOrder, v)
+		case *time.Time:
+			var nsec int64
+			err = binary.Read(reader, byteOrder, &nsec)
+			*v = time.Unix(0, nsec)
+		case **big.Int:
+			var d BigInt
+			err = d.Decode(reader)
+			*v = d.Int
+		case *[32]byte:
+			_, err = io.ReadFull(reader, v[:])
+		case *[]byte:
+			d := ByteSlice(*v)
+			err = d.Decode(reader)
+		case *string:
+			err = decodeString(reader, v)
+		default:
+			if dec, ok := value.(Decoder); ok {
+				err = dec.Decode(reader)
+			} else {
+				panic(fmt.Sprintf("polyio.Decode(): Invalid type %T", v))
+			}
+		}
+
+		if err != nil {
+			return errors.WithMessagef(err, "failed to decode %dth value of type %T", i, value)
+		}
+	}
+
+	return nil
+}

--- a/pkg/io/serializer.go
+++ b/pkg/io/serializer.go
@@ -12,34 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package channel
+package io
 
 import (
 	"io"
-	"math/rand"
-
-	"perun.network/go-perun/channel"
-	perunio "perun.network/go-perun/pkg/io"
 )
 
-// Asset simulates a `channel.Asset` by only containing an `ID`.
-type Asset struct {
-	ID int64
-}
+type (
+	// Serializer objects can be serialized into and from streams.
+	Serializer interface {
+		Encoder
+		Decoder
+	}
 
-var _ channel.Asset = new(Asset)
+	// An Encoder can encode itself into a stream.
+	Encoder interface {
+		// Encode writes itself to a stream.
+		// If the stream fails, the underlying error is returned.
+		Encode(io.Writer) error
+	}
 
-// NewRandomAsset returns a new random sim Asset.
-func NewRandomAsset(rng *rand.Rand) *Asset {
-	return &Asset{ID: rng.Int63()}
-}
-
-// Encode encodes a sim Asset into the io.Writer `w`.
-func (a Asset) Encode(w io.Writer) error {
-	return perunio.Encode(w, a.ID)
-}
-
-// Decode decodes a sim Asset from the io.Reader `r`.
-func (a *Asset) Decode(r io.Reader) error {
-	return perunio.Decode(r, &a.ID)
-}
+	// A Decoder can decode itself from a stream.
+	Decoder interface {
+		// Decode reads an object from a stream.
+		// If the stream fails, the underlying error is returned.
+		Decode(io.Reader) error
+	}
+)

--- a/pkg/io/string.go
+++ b/pkg/io/string.go
@@ -1,0 +1,58 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// encodeString writes the length as an uint16 and then the string itself to the io.Writer.
+func encodeString(w io.Writer, s string) error {
+	l := uint16(len(s))
+	if int(l) != len(s) {
+		return errors.Errorf("string length exceeded: %d", len(s))
+	}
+
+	if err := binary.Write(w, byteOrder, l); err != nil {
+		return errors.Wrap(err, "failed to write string length")
+	}
+
+	// Early exit. Plus, io.WriteString will complain about a closed io.Writer
+	// even if there is nothing left to write
+	if l == 0 {
+		return nil
+	}
+
+	_, err := io.WriteString(w, s)
+	return errors.Wrap(err, "failed to write string")
+}
+
+// decodeString reads the length as uint16 and the the string itself from the io.Reader.
+func decodeString(r io.Reader, s *string) error {
+	var l uint16
+	if err := binary.Read(r, byteOrder, &l); err != nil {
+		return errors.Wrap(err, "failed to read string length")
+	}
+
+	buf := make([]byte, l)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return errors.Wrap(err, "failed to read string")
+	}
+	*s = string(buf)
+	return nil
+}

--- a/pkg/io/string_internal_test.go
+++ b/pkg/io/string_internal_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	polytest "polycry.pt/poly-go/test"
+)
+
+func TestEncodeDecodeString(t *testing.T) {
+	assert := assert.New(t)
+	rng := polytest.Prng(t)
+	uint8buf, uint16buf := make([]byte, math.MaxUint8), make([]byte, math.MaxUint16)
+	rng.Read(uint8buf)
+	rng.Read(uint16buf)
+
+	t.Run("valid strings", func(t *testing.T) {
+		ss := []string{"", "a", "perun", string(uint8buf), string(uint16buf)}
+
+		for _, s := range ss {
+			r, w := io.Pipe()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				defer w.Close()
+				assert.NoError(encodeString(w, s))
+			}()
+
+			var d string
+			assert.NoError(decodeString(r, &d))
+			r.Close()
+			assert.Equal(s, d)
+			<-done
+		}
+	})
+
+	t.Run("too long string", func(t *testing.T) {
+		tooLong := string(append(uint16buf, 42)) // nolint: makezero
+		var buf bytes.Buffer
+		assert.Error(encodeString(&buf, tooLong))
+		assert.Zero(buf.Len(), "nothing should have been written to the stream")
+	})
+
+	t.Run("short stream", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := binary.Write(&buf, byteOrder, uint16(16))
+		require.NoError(t, err)
+		buf.Write(make([]byte, 8)) // 8 bytes missing
+
+		var d string
+		assert.Error(decodeString(&buf, &d))
+		assert.Zero(buf.Len(), "buffer should be exhausted")
+	})
+}

--- a/pkg/io/test/serializertest.go
+++ b/pkg/io/test/serializertest.go
@@ -1,0 +1,77 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test contains the generic serializer tests.
+package test // import "perun.network/go-perun/pkg/io/test"
+
+import (
+	"io"
+	"reflect"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	perunio "perun.network/go-perun/pkg/io"
+)
+
+// GenericSerializerTest runs multiple tests to check whether encoding
+// and decoding of serializer values works.
+func GenericSerializerTest(t *testing.T, serializers ...perunio.Serializer) {
+	t.Helper()
+	genericDecodeEncodeTest(t, serializers...)
+	GenericBrokenPipeTest(t, serializers...)
+}
+
+// genericDecodeEncodeTest tests whether encoding and then decoding
+// serializer values results in the original values.
+func genericDecodeEncodeTest(t *testing.T, serializers ...perunio.Serializer) {
+	t.Helper()
+	for i, v := range serializers {
+		r, w := io.Pipe()
+		br := iotest.OneByteReader(r)
+		go func() {
+			if err := perunio.Encode(w, v); err != nil {
+				t.Errorf("failed to encode %dth element (%T): %+v", i, v, err)
+			}
+			w.Close()
+		}()
+
+		dest := reflect.New(reflect.TypeOf(v).Elem())
+		err := perunio.Decode(br, dest.Interface().(perunio.Serializer))
+		r.Close()
+		if err != nil {
+			t.Errorf("failed to decode %dth element (%T): %+v", i, v, err)
+		} else {
+			_v := dest.Interface()
+			assert.Equalf(t, v, _v, "comparing element %d", i)
+		}
+	}
+}
+
+// GenericBrokenPipeTest tests that encoding and decoding on broken streams fails.
+func GenericBrokenPipeTest(t *testing.T, serializers ...perunio.Serializer) {
+	t.Helper()
+	for i, v := range serializers {
+		r, w := io.Pipe()
+		_ = w.Close()
+		if err := v.Encode(w); err == nil {
+			t.Errorf("encoding on closed writer should fail, but does not. %dth element (%T)", i, v)
+		}
+
+		_ = r.Close()
+		if err := v.Decode(r); err == nil {
+			t.Errorf("decoding on closed reader should fail, but does not. %dth element (%T)", i, v)
+		}
+	}
+}

--- a/pkg/io/wire_internal_test.go
+++ b/pkg/io/wire_internal_test.go
@@ -1,0 +1,113 @@
+// Copyright 2019 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"io"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	polytest "polycry.pt/poly-go/test"
+)
+
+func TestWrongTypes(t *testing.T) {
+	r, w := io.Pipe()
+
+	values := []interface{}{
+		errors.New(""),
+		float32(1.2),
+		float64(1.3),
+		complex(1, 2),
+		complex128(1),
+	}
+
+	d := make([]interface{}, len(values))
+	for _i, _v := range values {
+		v := _v
+		i := _i
+		panics, _ := polytest.CheckPanic(func() { _ = Encode(w, v) })
+		assert.True(t, panics, "Encode() must panic on invalid type %T", v)
+
+		d[i] = reflect.New(reflect.TypeOf(v)).Interface()
+		panics, _ = polytest.CheckPanic(func() { _ = Decode(r, d[i]) })
+		assert.True(t, panics, "Decode() must panic on invalid type %T", v)
+	}
+
+	polytest.CheckPanic(func() { _ = Decode(r, d...) })
+}
+
+func TestEncodeDecode(t *testing.T) {
+	a := assert.New(t)
+	r, w := io.Pipe()
+
+	longInt, _ := new(big.Int).SetString("12345671823897123798901234561234567890", 16)
+	var byte32 [32]byte
+	for i := byte(0); i < 32; i++ {
+		byte32[i] = i + 1
+	}
+	byteSlice := []byte{0, 1, 2, 4, 8, 0x10, 0x20, 0x40, 0x80}
+	values := []interface{}{
+		true,
+		byte(0xB0),
+		int8(-127),
+		uint8(0xB0),
+		uint16(0x1234),
+		uint32(0x123567),
+		uint64(0x1234567890123456),
+		int16(0x1234),
+		int32(0x123567),
+		int64(0x1234567890123456),
+		// The time has to be constructed this way, because otherwise DeepEqual fails.
+		time.Unix(0, time.Now().UnixNano()),
+		big.NewInt(0x1234567890123456),
+		longInt,
+		byte32,
+		byteSlice,
+		ByteSlice{5, 6, 8, 3, 4, 5, 6},
+		"perun",
+	}
+
+	go func() {
+		a.Nil(Encode(w, values...), "failed to encode values")
+	}()
+
+	d := make([]interface{}, len(values))
+	for i, v := range values {
+		if b, ok := v.([]byte); ok {
+			// destination byte slice has to be of correct size
+			e := make([]byte, len(b))
+			d[i] = &e
+		} else if b, ok = v.(ByteSlice); ok {
+			// destination ByteSlice has to be of correct size
+			e := make(ByteSlice, len(b))
+			d[i] = &e
+		} else {
+			d[i] = reflect.New(reflect.TypeOf(v)).Interface()
+		}
+	}
+
+	a.Nil(Decode(r, d...), "failed to decode values")
+
+	for i, v := range values {
+		if !reflect.DeepEqual(reflect.ValueOf(d[i]).Elem().Interface(), v) {
+			t.Errorf("%dth values are not the same: %T %v, %T %v", i, v, v, d[i], d[i])
+		}
+	}
+}

--- a/wallet/address.go
+++ b/wallet/address.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"polycry.pt/poly-go/io"
+	"perun.network/go-perun/pkg/io"
 )
 
 // Address represents a identifier used in a cryptocurrency.

--- a/wallet/address_test.go
+++ b/wallet/address_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "perun.network/go-perun/backend/sim/wallet"
+	iotest "perun.network/go-perun/pkg/io/test"
 	"perun.network/go-perun/wallet"
 	wallettest "perun.network/go-perun/wallet/test"
-	iotest "polycry.pt/poly-go/io/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/wallet/sig.go
+++ b/wallet/sig.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 )
 
 // Sig is a single signature.

--- a/wallet/test/wallet.go
+++ b/wallet/test/wallet.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	"polycry.pt/poly-go/io"
 )
 
 // InitWallet initializes a wallet.

--- a/wire/address.go
+++ b/wire/address.go
@@ -17,8 +17,8 @@ package wire
 import (
 	stdio "io"
 
+	"perun.network/go-perun/pkg/io"
 	"perun.network/go-perun/wallet"
-	"polycry.pt/poly-go/io"
 )
 
 var (

--- a/wire/controlmsgs.go
+++ b/wire/controlmsgs.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"time"
 
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 )
 
 func init() {

--- a/wire/msg.go
+++ b/wire/msg.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	perunio "polycry.pt/poly-go/io"
+	perunio "perun.network/go-perun/pkg/io"
 )
 
 type (

--- a/wire/msg_internal_test.go
+++ b/wire/msg_internal_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	iotest "perun.network/go-perun/pkg/io/test"
 	wtest "perun.network/go-perun/wallet/test"
-	iotest "polycry.pt/poly-go/io/test"
 	"polycry.pt/poly-go/test"
 )
 


### PR DESCRIPTION
- Because, the encoder/decoder implementations are specific to go-perun.

- And the package will be modified in upcoming changes.

Signed-off-by: Manoranjith <ponraj.manoranjitha@in.bosch.com>