### PR TITLE
Fix virtual channel proposal id generation

### DIFF
--- a/client/proposalmsgs.go
+++ b/client/proposalmsgs.go
@@ -192,17 +192,6 @@ func (p BaseChannelProposal) Encode(w io.Writer) error {
 		optAppAndDataEnc, p.InitBals, p.FundingAgreement)
 }
 
-// ProposalID returns the identifier of this channel proposal.
-func (p BaseChannelProposal) ProposalID() (propID ProposalID) {
-	hasher := newHasher()
-	if err := perunio.Encode(hasher, p.Base()); err != nil {
-		log.Panicf("proposal ID base encoding: %v", err)
-	}
-
-	copy(propID[:], hasher.Sum(nil))
-	return
-}
-
 // Decode decodes a BaseChannelProposal from an io.Reader.
 func (p *BaseChannelProposal) Decode(r io.Reader) (err error) {
 	if p.InitBals == nil {
@@ -618,6 +607,16 @@ func (p *VirtualChannelProposal) Decode(r io.Reader) error {
 // Type returns the message type.
 func (VirtualChannelProposal) Type() wire.Type {
 	return wire.VirtualChannelProposal
+}
+
+// ProposalID returns the identifier of this channel proposal.
+func (p VirtualChannelProposal) ProposalID() (propID ProposalID) {
+	hasher := newHasher()
+	if err := perunio.Encode(hasher, p); err != nil {
+		log.Panicf("proposal ID base encoding: %v", err)
+	}
+	copy(propID[:], hasher.Sum(nil))
+	return
 }
 
 // Accept constructs an accept message that belongs to a proposal message.

--- a/client/proposalmsgs.go
+++ b/client/proposalmsgs.go
@@ -278,13 +278,9 @@ func (LedgerChannelProposal) Type() wire.Type {
 // ProposalID returns the identifier of this channel proposal request.
 func (p LedgerChannelProposal) ProposalID() (propID ProposalID) {
 	hasher := newHasher()
-	if err := perunio.Encode(hasher,
-		p.Base(),
-		p.Participant,
-		wire.Addresses(p.Peers)); err != nil {
+	if err := perunio.Encode(hasher, p); err != nil {
 		log.Panicf("proposal ID nonce encoding: %v", err)
 	}
-
 	copy(propID[:], hasher.Sum(nil))
 	return
 }
@@ -354,12 +350,9 @@ func NewSubChannelProposal(
 // ProposalID returns the identifier of this channel proposal request.
 func (p SubChannelProposal) ProposalID() (propID ProposalID) {
 	hasher := newHasher()
-	if err := perunio.Encode(hasher,
-		p.Base(),
-		p.Parent); err != nil {
+	if err := perunio.Encode(hasher, p); err != nil {
 		log.Panicf("proposal ID nonce encoding: %v", err)
 	}
-
 	copy(propID[:], hasher.Sum(nil))
 	return
 }

--- a/client/proposalmsgs_test.go
+++ b/client/proposalmsgs_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
@@ -145,18 +146,52 @@ func TestSubChannelProposalReqProposalID(t *testing.T) {
 func TestVirtualChannelProposalReqProposalID(t *testing.T) {
 	rng := pkgtest.Prng(t)
 
-	prop, err := clienttest.NewRandomVirtualChannelProposal(rng)
+	original, err := clienttest.NewRandomVirtualChannelProposal(rng)
 	require.NoError(t, err)
+	assert.Equal(t, channel.NoApp(), original.App, "virtual channel should always has no app")
+	assert.Equal(t, channel.NoData(), original.InitData, "virtual channel should always has no data")
 
-	testProp := *prop
-	assert.Equal(t, prop.ProposalID(), testProp.ProposalID())
-
-	prop2, err := clienttest.NewRandomVirtualChannelProposal(rng)
+	fake, err := clienttest.NewRandomVirtualChannelProposal(rng)
 	require.NoError(t, err)
-	assert.NotEqual(t, prop.ProposalID(), prop2.ProposalID())
+	assert.Equal(t, channel.NoApp(), fake.App, "virtual channel should always has no app")
+	assert.Equal(t, channel.NoData(), fake.InitData, "virtual channel should always has no data")
 
-	testProp.NonceShare = prop2.NonceShare
-	assert.NotEqual(t, prop.ProposalID(), prop2.ProposalID())
+	assert.NotEqual(t, original.ChallengeDuration, fake.ChallengeDuration)
+	assert.NotEqual(t, original.NonceShare, fake.NonceShare)
+	assert.NotEqual(t, original.InitBals, fake.InitBals)
+	assert.NotEqual(t, original.FundingAgreement, fake.FundingAgreement)
+	assert.NotEqual(t, original.Proposer, fake.Proposer)
+	assert.NotEqual(t, original.Peers, fake.Peers)
+	assert.NotEqual(t, original.Parents, fake.Parents)
+	assert.NotEqual(t, original.IndexMaps, fake.IndexMaps)
+
+	testProp := *original
+	testProp.ChallengeDuration = fake.ChallengeDuration
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
+
+	testProp = *original
+	testProp.NonceShare = fake.NonceShare
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
+
+	testProp = *original
+	testProp.InitBals = fake.InitBals
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
+
+	testProp = *original
+	testProp.FundingAgreement = fake.FundingAgreement
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
+
+	testProp = *original
+	testProp.Proposer = fake.Proposer
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
+
+	testProp = *original
+	testProp.Peers = fake.Peers
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
+
+	testProp = *original
+	testProp.IndexMaps = fake.IndexMaps
+	assert.NotEqual(t, original.ProposalID(), testProp.ProposalID())
 }
 
 func TestChannelProposalAccSerialization(t *testing.T) {


### PR DESCRIPTION
- Previously, the proposal ID for a virtual channel was generated using
  the ProposalID method defined on BaseChannelProposal.

- Hence, not all parameters of the virtual channel proposal were used.

- Fix it by defining a ProposalID method on the virtual channel.

- Also, remove the ProposalID method on the BaseChannelProposal, as it
  is not needed.

Fixes #299.