### PR TITLE
Rename wire message types

### DIFF
--- a/client/channel.go
+++ b/client/channel.go
@@ -209,7 +209,7 @@ func (c *Channel) initExchangeSigsAndEnable(ctx context.Context) error {
 
 	send := make(chan error)
 	go func() {
-		send <- c.conn.Send(ctx, &msgChannelUpdateAcc{
+		send <- c.conn.Send(ctx, &ChannelUpdateAccMsg{
 			ChannelID: c.ID(),
 			Version:   0,
 			Sig:       sig,
@@ -220,7 +220,7 @@ func (c *Channel) initExchangeSigsAndEnable(ctx context.Context) error {
 	if err != nil {
 		return errors.WithMessage(err, "receiving initial state sig")
 	}
-	acc, ok := cm.(*msgChannelUpdateAcc)
+	acc, ok := cm.(*ChannelUpdateAccMsg)
 	if !ok {
 		return errors.Errorf(
 			"received unexpected message of type (%T) from peer[%d]: %v",

--- a/client/client.go
+++ b/client/client.go
@@ -183,7 +183,7 @@ func (c *Client) Handle(ph ProposalHandler, uh UpdateHandler) {
 			go c.handleChannelUpdate(uh, env.Sender, msg)
 		case *VirtualChannelSettlementProposalMsg:
 			go c.handleChannelUpdate(uh, env.Sender, msg)
-		case *msgChannelSync:
+		case *ChannelSyncMsg:
 			go c.handleSyncMsg(env.Sender, msg)
 		default:
 			c.log.Error("Unexpected %T message received in request loop")

--- a/client/client.go
+++ b/client/client.go
@@ -177,11 +177,11 @@ func (c *Client) Handle(ph ProposalHandler, uh UpdateHandler) {
 			go c.handleChannelProposal(ph, env.Sender, msg)
 		case *VirtualChannelProposalMsg:
 			go c.handleChannelProposal(ph, env.Sender, msg)
-		case *msgChannelUpdate:
+		case *ChannelUpdateMsg:
 			go c.handleChannelUpdate(uh, env.Sender, msg)
-		case *virtualChannelFundingProposal:
+		case *VirtualChannelFundingProposalMsg:
 			go c.handleChannelUpdate(uh, env.Sender, msg)
-		case *virtualChannelSettlementProposal:
+		case *VirtualChannelSettlementProposalMsg:
 			go c.handleChannelUpdate(uh, env.Sender, msg)
 		case *msgChannelSync:
 			go c.handleSyncMsg(env.Sender, msg)

--- a/client/client.go
+++ b/client/client.go
@@ -171,11 +171,11 @@ func (c *Client) Handle(ph ProposalHandler, uh UpdateHandler) {
 		msg := env.Msg
 
 		switch msg := msg.(type) {
-		case *LedgerChannelProposal:
+		case *LedgerChannelProposalMsg:
 			go c.handleChannelProposal(ph, env.Sender, msg)
-		case *SubChannelProposal:
+		case *SubChannelProposalMsg:
 			go c.handleChannelProposal(ph, env.Sender, msg)
-		case *VirtualChannelProposal:
+		case *VirtualChannelProposalMsg:
 			go c.handleChannelProposal(ph, env.Sender, msg)
 		case *msgChannelUpdate:
 			go c.handleChannelUpdate(uh, env.Sender, msg)

--- a/client/proposal.go
+++ b/client/proposal.go
@@ -279,7 +279,7 @@ func (c *Client) handleChannelProposalRej(
 	ctx context.Context, p wire.Address,
 	req ChannelProposal, reason string,
 ) error {
-	msgReject := &ChannelProposalRej{
+	msgReject := &ChannelProposalRejMsg{
 		ProposalID: req.ProposalID(),
 		Reason:     reason,
 	}
@@ -310,7 +310,7 @@ func (c *Client) proposeTwoPartyChannel(
 		acc, isAcc := e.Msg.(ChannelProposalAccept)
 		return (isAcc && acc.Base().ProposalID == proposalID) ||
 			(e.Msg.Type() == wire.ChannelProposalRej &&
-				e.Msg.(*ChannelProposalRej).ProposalID == proposalID)
+				e.Msg.(*ChannelProposalRejMsg).ProposalID == proposalID)
 	}
 	receiver := wire.NewReceiver()
 	defer receiver.Close()
@@ -330,7 +330,7 @@ func (c *Client) proposeTwoPartyChannel(
 		}
 		return nil, errors.WithMessage(err, "receiving proposal response")
 	}
-	if rej, ok := env.Msg.(*ChannelProposalRej); ok {
+	if rej, ok := env.Msg.(*ChannelProposalRejMsg); ok {
 		return nil, newPeerRejectedError("channel proposal", rej.Reason)
 	}
 
@@ -384,11 +384,11 @@ func (c *Client) validTwoPartyProposal(
 	}
 
 	switch prop := proposal.(type) {
-	case *SubChannelProposal:
+	case *SubChannelProposalMsg:
 		if err := c.validSubChannelProposal(prop); err != nil {
 			return errors.WithMessage(err, "validate subchannel proposal")
 		}
-	case *VirtualChannelProposal:
+	case *VirtualChannelProposalMsg:
 		if err := c.validVirtualChannelProposal(prop, ourIdx); err != nil {
 			return errors.WithMessage(err, "validate subchannel proposal")
 		}
@@ -397,7 +397,7 @@ func (c *Client) validTwoPartyProposal(
 	return nil
 }
 
-func (c *Client) validSubChannelProposal(proposal *SubChannelProposal) error {
+func (c *Client) validSubChannelProposal(proposal *SubChannelProposalMsg) error {
 	parent, ok := c.channels.Channel(proposal.Parent)
 	if !ok {
 		return errors.New("parent channel does not exist")
@@ -417,7 +417,7 @@ func (c *Client) validSubChannelProposal(proposal *SubChannelProposal) error {
 	return nil
 }
 
-func (c *Client) validVirtualChannelProposal(prop *VirtualChannelProposal, ourIdx channel.Index) error {
+func (c *Client) validVirtualChannelProposal(prop *VirtualChannelProposalMsg, ourIdx channel.Index) error {
 	numParents := len(prop.Parents)
 	numPeers := prop.NumPeers()
 	if numParents != numPeers {
@@ -569,9 +569,9 @@ func (c *Client) completeCPP(
 
 func (c *Client) proposalParent(prop ChannelProposal, partIdx channel.Index) (parentChannelID *channel.ID, parent *Channel, err error) {
 	switch prop := prop.(type) {
-	case *SubChannelProposal:
+	case *SubChannelProposalMsg:
 		parentChannelID = &prop.Parent
-	case *VirtualChannelProposal:
+	case *VirtualChannelProposalMsg:
 		parentChannelID = &prop.Parents[partIdx]
 	}
 
@@ -591,20 +591,20 @@ func (c *Client) mpcppParts(
 	acc ChannelProposalAccept,
 ) (parts []wallet.Address) {
 	switch p := prop.(type) {
-	case *LedgerChannelProposal:
+	case *LedgerChannelProposalMsg:
 		parts = participants(
 			p.Participant,
-			acc.(*LedgerChannelProposalAcc).Participant)
-	case *SubChannelProposal:
+			acc.(*LedgerChannelProposalAccMsg).Participant)
+	case *SubChannelProposalMsg:
 		ch, ok := c.channels.Channel(p.Parent)
 		if !ok {
 			c.log.Panic("unknown parent channel ID")
 		}
 		parts = ch.Params().Parts
-	case *VirtualChannelProposal:
+	case *VirtualChannelProposalMsg:
 		parts = participants(
 			p.Proposer,
-			acc.(*VirtualChannelProposalAcc).Responder,
+			acc.(*VirtualChannelProposalAccMsg).Responder,
 		)
 	default:
 		c.log.Panicf("unhandled %T", p)
@@ -614,13 +614,13 @@ func (c *Client) mpcppParts(
 
 func (c *Client) fundChannel(ctx context.Context, ch *Channel, prop ChannelProposal) error {
 	switch prop := prop.(type) {
-	case *LedgerChannelProposal:
+	case *LedgerChannelProposalMsg:
 		err := c.fundLedgerChannel(ctx, ch, prop.Base().FundingAgreement)
 		return errors.WithMessage(err, "funding ledger channel")
-	case *SubChannelProposal:
+	case *SubChannelProposalMsg:
 		err := c.fundSubchannel(ctx, prop, ch)
 		return errors.WithMessage(err, "funding subchannel")
-	case *VirtualChannelProposal:
+	case *VirtualChannelProposalMsg:
 		err := c.fundVirtualChannel(ctx, ch, prop)
 		return errors.WithMessage(err, "funding virtual channel")
 	}
@@ -657,7 +657,7 @@ func (c *Client) fundLedgerChannel(ctx context.Context, ch *Channel, agreement c
 	return c.completeFunding(ctx, ch)
 }
 
-func (c *Client) fundSubchannel(ctx context.Context, prop *SubChannelProposal, subChannel *Channel) (err error) {
+func (c *Client) fundSubchannel(ctx context.Context, prop *SubChannelProposalMsg, subChannel *Channel) (err error) {
 	parentChannel, ok := c.channels.Channel(prop.Parent)
 	if !ok {
 		return errors.New("referenced parent channel not found")

--- a/client/proposal.go
+++ b/client/proposal.go
@@ -684,7 +684,7 @@ func (c *Client) fundSubchannel(ctx context.Context, prop *SubChannelProposalMsg
 func enableVer0Cache(c wire.Cacher) *wire.Predicate {
 	p := func(m *wire.Envelope) bool {
 		return m.Msg.Type() == wire.ChannelUpdateAcc &&
-			m.Msg.(*msgChannelUpdateAcc).Version == 0
+			m.Msg.(*ChannelUpdateAccMsg).Version == 0
 	}
 	c.Cache(&p)
 	return &p

--- a/client/proposal_internal_test.go
+++ b/client/proposal_internal_test.go
@@ -45,12 +45,12 @@ func TestClient_validTwoPartyProposal(t *testing.T) {
 	require.Len(t, validProp.Peers, 2)
 
 	validProp3Peers := NewRandomLedgerChannelProposal(rng, channeltest.WithNumParts(3))
-	invalidProp := &LedgerChannelProposal{}
+	invalidProp := &LedgerChannelProposalMsg{}
 	*invalidProp = *validProp                // shallow copy
 	invalidProp.Base().ChallengeDuration = 0 // invalidate
 
 	tests := []struct {
-		prop     *LedgerChannelProposal
+		prop     *LedgerChannelProposalMsg
 		ourIdx   channel.Index
 		peerAddr wallet.Address
 		valid    bool
@@ -104,7 +104,7 @@ func TestChannelProposal_assertValidNumParts(t *testing.T) {
 
 func TestProposalResponder_Accept_Nil(t *testing.T) {
 	p := new(ProposalResponder)
-	_, err := p.Accept(nil, new(LedgerChannelProposalAcc)) //nolint:staticcheck
+	_, err := p.Accept(nil, new(LedgerChannelProposalAccMsg)) //nolint:staticcheck
 	assert.Error(t, err, "context")
 }
 
@@ -149,11 +149,11 @@ func NewRandomBaseChannelProposal(rng *rand.Rand, opts ...channeltest.RandomOpt)
 	return prop
 }
 
-func NewRandomLedgerChannelProposal(rng *rand.Rand, opts ...channeltest.RandomOpt) *LedgerChannelProposal {
+func NewRandomLedgerChannelProposal(rng *rand.Rand, opts ...channeltest.RandomOpt) *LedgerChannelProposalMsg {
 	opt := make(channeltest.RandomOpt).Append(opts...)
 	base := NewRandomBaseChannelProposal(rng, opt)
 	peers := wiretest.NewRandomAddresses(rng, base.NumPeers())
-	return &LedgerChannelProposal{
+	return &LedgerChannelProposalMsg{
 		BaseChannelProposal: base,
 		Participant:         wallettest.NewRandomAddress(rng),
 		Peers:               peers,

--- a/client/proposalmsgs_test.go
+++ b/client/proposalmsgs_test.go
@@ -228,7 +228,7 @@ func TestChannelProposalAccSerialization(t *testing.T) {
 func TestChannelProposalRejSerialization(t *testing.T) {
 	rng := pkgtest.Prng(t)
 	for i := 0; i < 16; i++ {
-		m := &client.ChannelProposalRej{
+		m := &client.ChannelProposalRejMsg{
 			ProposalID: newRandomProposalID(rng),
 			Reason:     newRandomString(rng, 16, 16),
 		}

--- a/client/sync.go
+++ b/client/sync.go
@@ -32,7 +32,7 @@ var syncReplyTimeout = 10 * time.Second
 // exists, it just sends the current channel data to the requester. If the
 // own channel is in the Signing phase, the ongoing update is discarded so that
 // the channel is reverted to the Acting phase.
-func (c *Client) handleSyncMsg(peer wire.Address, msg *msgChannelSync) {
+func (c *Client) handleSyncMsg(peer wire.Address, msg *ChannelSyncMsg) {
 	log := c.logChan(msg.ID()).WithField("peer", peer)
 	ch, ok := c.channels.Channel(msg.ID())
 	if !ok {
@@ -99,7 +99,7 @@ func (c *Client) syncChannel(ctx context.Context, ch *persistence.Channel, p wir
 	if err != nil {
 		return errors.WithMessage(err, "receiving sync message")
 	}
-	msg, ok := env.Msg.(*msgChannelSync)
+	msg, ok := env.Msg.(*ChannelSyncMsg)
 	if !ok {
 		log.Panic("internal error: wrong message type")
 	}
@@ -117,7 +117,7 @@ func (c *Client) syncChannel(ctx context.Context, ch *persistence.Channel, p wir
 
 // validateMessage validates the remote channel sync message.
 // nolint:unused, nestif
-func validateMessage(ch *persistence.Channel, msg *msgChannelSync) error {
+func validateMessage(ch *persistence.Channel, msg *ChannelSyncMsg) error {
 	v := ch.CurrentTX().Version
 	mv := msg.CurrentTX.Version
 

--- a/client/syncmsgs.go
+++ b/client/syncmsgs.go
@@ -25,45 +25,47 @@ import (
 func init() {
 	wire.RegisterDecoder(wire.ChannelSync,
 		func(r io.Reader) (wire.Msg, error) {
-			var m msgChannelSync
+			var m ChannelSyncMsg
 			return &m, m.Decode(r)
 		})
 }
 
-type msgChannelSync struct {
+// ChannelSyncMsg is the wire message for syncing channel states across
+// multiple clients.
+type ChannelSyncMsg struct {
 	Phase     channel.Phase       // Phase is the phase of the sender.
 	CurrentTX channel.Transaction // CurrentTX is the sender's current transaction.
 }
 
-var _ ChannelMsg = (*msgChannelSync)(nil)
+var _ ChannelMsg = (*ChannelSyncMsg)(nil)
 
-func newChannelSyncMsg(s channel.Source) *msgChannelSync {
-	return &msgChannelSync{
+func newChannelSyncMsg(s channel.Source) *ChannelSyncMsg {
+	return &ChannelSyncMsg{
 		Phase:     s.Phase(),
 		CurrentTX: s.CurrentTX(),
 	}
 }
 
 // Encode implements perunio.Encode.
-func (m *msgChannelSync) Encode(w io.Writer) error {
+func (m *ChannelSyncMsg) Encode(w io.Writer) error {
 	return perunio.Encode(w,
 		m.Phase,
 		m.CurrentTX)
 }
 
 // Decode implements perunio.Decode.
-func (m *msgChannelSync) Decode(r io.Reader) error {
+func (m *ChannelSyncMsg) Decode(r io.Reader) error {
 	return perunio.Decode(r,
 		&m.Phase,
 		&m.CurrentTX)
 }
 
 // ID returns the channel's ID.
-func (m *msgChannelSync) ID() channel.ID {
+func (m *ChannelSyncMsg) ID() channel.ID {
 	return m.CurrentTX.ID
 }
 
 // Type implements wire.Type.
-func (m *msgChannelSync) Type() wire.Type {
+func (m *ChannelSyncMsg) Type() wire.Type {
 	return wire.ChannelSync
 }

--- a/client/test/randomproposal.go
+++ b/client/test/randomproposal.go
@@ -29,14 +29,14 @@ const randomProposalNumParts = 2
 
 // NewRandomLedgerChannelProposal creates a random channel proposal with the supplied
 // options. Number of participants is fixed to randomProposalNumParts.
-func NewRandomLedgerChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) *client.LedgerChannelProposal {
+func NewRandomLedgerChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) *client.LedgerChannelProposalMsg {
 	return NewRandomLedgerChannelProposalBy(rng, wallettest.NewRandomAddress(rng), opts...)
 }
 
 // NewRandomLedgerChannelProposalBy creates a random channel proposal with the
 // supplied options and proposer. Number of participants is fixed to
 // randomProposalNumParts.
-func NewRandomLedgerChannelProposalBy(rng *rand.Rand, proposer wallet.Address, opts ...client.ProposalOpts) *client.LedgerChannelProposal {
+func NewRandomLedgerChannelProposalBy(rng *rand.Rand, proposer wallet.Address, opts ...client.ProposalOpts) *client.LedgerChannelProposalMsg {
 	prop, err := client.NewLedgerChannelProposal(
 		rng.Uint64(),
 		proposer,
@@ -51,7 +51,7 @@ func NewRandomLedgerChannelProposalBy(rng *rand.Rand, proposer wallet.Address, o
 
 // NewRandomSubChannelProposal creates a random subchannel proposal with the
 // supplied options. Number of participants is fixed to 2.
-func NewRandomSubChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) (*client.SubChannelProposal, error) {
+func NewRandomSubChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) (*client.SubChannelProposalMsg, error) {
 	return client.NewSubChannelProposal(
 		channeltest.NewRandomChannelID(rng),
 		rng.Uint64(),
@@ -61,7 +61,7 @@ func NewRandomSubChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) (*
 
 // NewRandomVirtualChannelProposal creates a random virtual channel proposal with the
 // supplied options. Number of participants is fixed to 2.
-func NewRandomVirtualChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) (*client.VirtualChannelProposal, error) {
+func NewRandomVirtualChannelProposal(rng *rand.Rand, opts ...client.ProposalOpts) (*client.VirtualChannelProposalMsg, error) {
 	numParts := 2
 	return client.NewVirtualChannelProposal(
 		rng.Uint64(),

--- a/client/test/role.go
+++ b/client/test/role.go
@@ -315,7 +315,7 @@ func (r *role) GoHandle(rng *rand.Rand) (h *acceptNextPropHandler, wait func()) 
 	}
 }
 
-func (r *role) LedgerChannelProposal(rng *rand.Rand, cfg ExecConfig) *client.LedgerChannelProposal {
+func (r *role) LedgerChannelProposal(rng *rand.Rand, cfg ExecConfig) *client.LedgerChannelProposalMsg {
 	if !cfg.App().SetsApp() {
 		r.log.Panic("Invalid ExecConfig: App does not specify an app.")
 	}
@@ -343,7 +343,7 @@ func (r *role) SubChannelProposal(
 	parent *client.Channel,
 	initBals *channel.Allocation,
 	app client.ProposalOpts,
-) *client.SubChannelProposal {
+) *client.SubChannelProposalMsg {
 	if !cfg.App().SetsApp() {
 		r.log.Panic("Invalid ExecConfig: App does not specify an app.")
 	}
@@ -394,12 +394,12 @@ func (h *acceptNextPropHandler) Next() (*paymentChannel, error) {
 
 	var acc client.ChannelProposalAccept
 	switch p := prop.(type) {
-	case *client.LedgerChannelProposal:
+	case *client.LedgerChannelProposalMsg:
 		part := h.r.setup.Wallet.NewRandomAccount(h.rng).Address()
 		acc = p.Accept(part, client.WithNonceFrom(h.rng))
 		h.r.log.Debugf("Accepting ledger channel proposal with participant: %v", part)
 
-	case *client.SubChannelProposal:
+	case *client.SubChannelProposalMsg:
 		acc = p.Accept(client.WithNonceFrom(h.rng))
 		h.r.log.Debug("Accepting sub-channel proposal")
 

--- a/client/updatemsgs.go
+++ b/client/updatemsgs.go
@@ -26,27 +26,27 @@ import (
 func init() {
 	wire.RegisterDecoder(wire.ChannelUpdate,
 		func(r io.Reader) (wire.Msg, error) {
-			var m msgChannelUpdate
+			var m ChannelUpdateMsg
 			return &m, m.Decode(r)
 		})
 	wire.RegisterDecoder(wire.ChannelUpdateAcc,
 		func(r io.Reader) (wire.Msg, error) {
-			var m msgChannelUpdateAcc
+			var m ChannelUpdateAccMsg
 			return &m, m.Decode(r)
 		})
 	wire.RegisterDecoder(wire.ChannelUpdateRej,
 		func(r io.Reader) (wire.Msg, error) {
-			var m msgChannelUpdateRej
+			var m ChannelUpdateRejMsg
 			return &m, m.Decode(r)
 		})
 	wire.RegisterDecoder(wire.VirtualChannelFundingProposal,
 		func(r io.Reader) (wire.Msg, error) {
-			var m virtualChannelFundingProposal
+			var m VirtualChannelFundingProposalMsg
 			return &m, m.Decode(r)
 		})
 	wire.RegisterDecoder(wire.VirtualChannelSettlementProposal,
 		func(r io.Reader) (wire.Msg, error) {
-			var m virtualChannelSettlementProposal
+			var m VirtualChannelSettlementProposalMsg
 			return &m, m.Decode(r)
 		})
 }
@@ -64,9 +64,9 @@ type (
 		Ver() uint64
 	}
 
-	// msgChannelUpdate is the wire message of a channel update proposal. It
+	// ChannelUpdateMsg is the wire message of a channel update proposal. It
 	// additionally holds the signature on the proposed state.
-	msgChannelUpdate struct {
+	ChannelUpdateMsg struct {
 		ChannelUpdate
 		// Sig is the signature on the proposed state by the peer sending the
 		// ChannelUpdate.
@@ -77,13 +77,13 @@ type (
 	ChannelUpdateProposal interface {
 		wire.Msg
 		perunio.Decoder
-		Base() *msgChannelUpdate
+		Base() *ChannelUpdateMsg
 	}
 
-	// msgChannelUpdateAcc is the wire message sent as a positive reply to a
+	// ChannelUpdateAccMsg is the wire message sent as a positive reply to a
 	// ChannelUpdate.  It references the channel ID and version and contains the
 	// signature on the accepted new state by the sender.
-	msgChannelUpdateAcc struct {
+	ChannelUpdateAccMsg struct {
 		// ChannelID is the channel ID.
 		ChannelID channel.ID
 		// Version of the state that is accepted.
@@ -92,10 +92,10 @@ type (
 		Sig wallet.Sig
 	}
 
-	// msgChannelUpdateRej is the wire message sent as a negative reply to a
+	// ChannelUpdateRejMsg is the wire message sent as a negative reply to a
 	// ChannelUpdate.  It references the channel ID and version and states a
 	// reason for the rejection.
-	msgChannelUpdateRej struct {
+	ChannelUpdateRejMsg struct {
 		// ChannelID is the channel ID.
 		ChannelID channel.ID
 		// Version of the state that is accepted.
@@ -106,36 +106,38 @@ type (
 )
 
 var (
-	_ ChannelMsg          = (*msgChannelUpdate)(nil)
-	_ channelUpdateResMsg = (*msgChannelUpdateAcc)(nil)
-	_ channelUpdateResMsg = (*msgChannelUpdateRej)(nil)
+	_ ChannelMsg          = (*ChannelUpdateMsg)(nil)
+	_ channelUpdateResMsg = (*ChannelUpdateAccMsg)(nil)
+	_ channelUpdateResMsg = (*ChannelUpdateRejMsg)(nil)
 )
 
 // Type returns this message's type: ChannelUpdate.
-func (*msgChannelUpdate) Type() wire.Type {
+func (*ChannelUpdateMsg) Type() wire.Type {
 	return wire.ChannelUpdate
 }
 
 // Type returns this message's type: ChannelUpdateAcc.
-func (*msgChannelUpdateAcc) Type() wire.Type {
+func (*ChannelUpdateAccMsg) Type() wire.Type {
 	return wire.ChannelUpdateAcc
 }
 
 // Type returns this message's type: ChannelUpdateRej.
-func (*msgChannelUpdateRej) Type() wire.Type {
+func (*ChannelUpdateRejMsg) Type() wire.Type {
 	return wire.ChannelUpdateRej
 }
 
 // Base returns the core channel update message.
-func (c *msgChannelUpdate) Base() *msgChannelUpdate {
+func (c *ChannelUpdateMsg) Base() *ChannelUpdateMsg {
 	return c
 }
 
-func (c msgChannelUpdate) Encode(w io.Writer) error {
+// Encode encodes the ChannelUpdateMsg into the io.Writer.
+func (c ChannelUpdateMsg) Encode(w io.Writer) error {
 	return perunio.Encode(w, c.State, c.ActorIdx, c.Sig)
 }
 
-func (c *msgChannelUpdate) Decode(r io.Reader) (err error) {
+// Decode decodes the ChannelUpdateMsg from the io.Reader.
+func (c *ChannelUpdateMsg) Decode(r io.Reader) (err error) {
 	if c.State == nil {
 		c.State = new(channel.State)
 	}
@@ -146,11 +148,13 @@ func (c *msgChannelUpdate) Decode(r io.Reader) (err error) {
 	return err
 }
 
-func (c msgChannelUpdateAcc) Encode(w io.Writer) error {
+// Encode encodes the ChannelUpdateAccMsg into the io.Writer.
+func (c ChannelUpdateAccMsg) Encode(w io.Writer) error {
 	return perunio.Encode(w, c.ChannelID, c.Version, c.Sig)
 }
 
-func (c *msgChannelUpdateAcc) Decode(r io.Reader) (err error) {
+// Decode decodes the ChannelUpdateAccMsg from the io.Reader.
+func (c *ChannelUpdateAccMsg) Decode(r io.Reader) (err error) {
 	if err := perunio.Decode(r, &c.ChannelID, &c.Version); err != nil {
 		return err
 	}
@@ -158,36 +162,38 @@ func (c *msgChannelUpdateAcc) Decode(r io.Reader) (err error) {
 	return err
 }
 
-func (c msgChannelUpdateRej) Encode(w io.Writer) error {
+// Encode encodes the ChannelUpdateRejMsg into the io.Writer.
+func (c ChannelUpdateRejMsg) Encode(w io.Writer) error {
 	return perunio.Encode(w, c.ChannelID, c.Version, c.Reason)
 }
 
-func (c *msgChannelUpdateRej) Decode(r io.Reader) (err error) {
+// Decode decodes the ChannelUpdateRejMsg from the io.Reader.
+func (c *ChannelUpdateRejMsg) Decode(r io.Reader) (err error) {
 	return perunio.Decode(r, &c.ChannelID, &c.Version, &c.Reason)
 }
 
 // ID returns the id of the channel this update refers to.
-func (c *msgChannelUpdate) ID() channel.ID {
+func (c *ChannelUpdateMsg) ID() channel.ID {
 	return c.State.ID
 }
 
 // ID returns the id of the channel this update acceptance refers to.
-func (c *msgChannelUpdateAcc) ID() channel.ID {
+func (c *ChannelUpdateAccMsg) ID() channel.ID {
 	return c.ChannelID
 }
 
 // ID returns the id of the channel this update rejection refers to.
-func (c *msgChannelUpdateRej) ID() channel.ID {
+func (c *ChannelUpdateRejMsg) ID() channel.ID {
 	return c.ChannelID
 }
 
 // Ver returns the version of the state this update acceptance refers to.
-func (c *msgChannelUpdateAcc) Ver() uint64 {
+func (c *ChannelUpdateAccMsg) Ver() uint64 {
 	return c.Version
 }
 
 // Ver returns the version of the state this update rejection refers to.
-func (c *msgChannelUpdateRej) Ver() uint64 {
+func (c *ChannelUpdateRejMsg) Ver() uint64 {
 	return c.Version
 }
 
@@ -196,28 +202,29 @@ Virtual channel
 */
 
 type (
-	// virtualChannelFundingProposal is a channel update that proposes the funding of a virtual channel.
-	virtualChannelFundingProposal struct {
-		msgChannelUpdate
+	// VirtualChannelFundingProposalMsg is a channel update that proposes the funding of a virtual channel.
+	VirtualChannelFundingProposalMsg struct {
+		ChannelUpdateMsg
 		Initial  channel.SignedState
 		IndexMap []channel.Index
 	}
 
-	// virtualChannelSettlementProposal is a channel update that proposes the settlement of a virtual channel.
-	virtualChannelSettlementProposal struct {
-		msgChannelUpdate
+	// VirtualChannelSettlementProposalMsg is a channel update that proposes the settlement of a virtual channel.
+	VirtualChannelSettlementProposalMsg struct {
+		ChannelUpdateMsg
 		Final channel.SignedState
 	}
 )
 
 // Type returns the message type.
-func (*virtualChannelFundingProposal) Type() wire.Type {
+func (*VirtualChannelFundingProposalMsg) Type() wire.Type {
 	return wire.VirtualChannelFundingProposal
 }
 
-func (m virtualChannelFundingProposal) Encode(w io.Writer) (err error) {
+// Encode encodes the VirtualChannelFundingProposalMsg into the io.Writer.
+func (m VirtualChannelFundingProposalMsg) Encode(w io.Writer) (err error) {
 	err = perunio.Encode(w,
-		m.msgChannelUpdate,
+		m.ChannelUpdateMsg,
 		m.Initial.Params,
 		*m.Initial.State,
 		indexMapWithLen(m.IndexMap),
@@ -229,13 +236,14 @@ func (m virtualChannelFundingProposal) Encode(w io.Writer) (err error) {
 	return wallet.EncodeSparseSigs(w, m.Initial.Sigs)
 }
 
-func (m *virtualChannelFundingProposal) Decode(r io.Reader) (err error) {
+// Decode decodes the VirtualChannelFundingProposalMsg from the io.Reader.
+func (m *VirtualChannelFundingProposalMsg) Decode(r io.Reader) (err error) {
 	m.Initial = channel.SignedState{
 		Params: &channel.Params{},
 		State:  &channel.State{},
 	}
 	err = perunio.Decode(r,
-		&m.msgChannelUpdate,
+		&m.ChannelUpdateMsg,
 		m.Initial.Params,
 		m.Initial.State,
 		(*indexMapWithLen)(&m.IndexMap),
@@ -249,13 +257,14 @@ func (m *virtualChannelFundingProposal) Decode(r io.Reader) (err error) {
 }
 
 // Type returns the message type.
-func (*virtualChannelSettlementProposal) Type() wire.Type {
+func (*VirtualChannelSettlementProposalMsg) Type() wire.Type {
 	return wire.VirtualChannelSettlementProposal
 }
 
-func (m virtualChannelSettlementProposal) Encode(w io.Writer) (err error) {
+// Encode encodes the VirtualChannelSettlementProposalMsg into the io.Writer.
+func (m VirtualChannelSettlementProposalMsg) Encode(w io.Writer) (err error) {
 	err = perunio.Encode(w,
-		m.msgChannelUpdate,
+		m.ChannelUpdateMsg,
 		m.Final.Params,
 		*m.Final.State,
 	)
@@ -266,13 +275,14 @@ func (m virtualChannelSettlementProposal) Encode(w io.Writer) (err error) {
 	return wallet.EncodeSparseSigs(w, m.Final.Sigs)
 }
 
-func (m *virtualChannelSettlementProposal) Decode(r io.Reader) (err error) {
+// Decode decodes the VirtualChannelSettlementProposalMsg from the io.Reader.
+func (m *VirtualChannelSettlementProposalMsg) Decode(r io.Reader) (err error) {
 	m.Final = channel.SignedState{
 		Params: &channel.Params{},
 		State:  &channel.State{},
 	}
 	err = perunio.Decode(r,
-		&m.msgChannelUpdate,
+		&m.ChannelUpdateMsg,
 		m.Final.Params,
 		m.Final.State,
 	)

--- a/client/updatemsgs_internal_test.go
+++ b/client/updatemsgs_internal_test.go
@@ -34,10 +34,10 @@ func TestChannelUpdateSerialization(t *testing.T) {
 	}
 }
 
-func newRandomMsgChannelUpdate(rng *rand.Rand) *msgChannelUpdate {
+func newRandomMsgChannelUpdate(rng *rand.Rand) *ChannelUpdateMsg {
 	state := test.NewRandomState(rng)
 	sig := newRandomSig(rng)
-	return &msgChannelUpdate{
+	return &ChannelUpdateMsg{
 		ChannelUpdate: ChannelUpdate{
 			State:    state,
 			ActorIdx: channel.Index(rng.Intn(state.NumParts())),
@@ -51,8 +51,8 @@ func TestSerialization_VirtualChannelFundingProposal(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		msgUp := newRandomMsgChannelUpdate(rng)
 		params, state := test.NewRandomParamsAndState(rng)
-		m := &virtualChannelFundingProposal{
-			msgChannelUpdate: *msgUp,
+		m := &VirtualChannelFundingProposalMsg{
+			ChannelUpdateMsg: *msgUp,
 			Initial: channel.SignedState{
 				Params: params,
 				State:  state,
@@ -69,8 +69,8 @@ func TestSerialization_VirtualChannelSettlementProposal(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		msgUp := newRandomMsgChannelUpdate(rng)
 		params, state := test.NewRandomParamsAndState(rng)
-		m := &virtualChannelSettlementProposal{
-			msgChannelUpdate: *msgUp,
+		m := &VirtualChannelSettlementProposalMsg{
+			ChannelUpdateMsg: *msgUp,
 			Final: channel.SignedState{
 				Params: params,
 				State:  state,
@@ -85,7 +85,7 @@ func TestChannelUpdateAccSerialization(t *testing.T) {
 	rng := pkgtest.Prng(t)
 	for i := 0; i < 4; i++ {
 		sig := newRandomSig(rng)
-		m := &msgChannelUpdateAcc{
+		m := &ChannelUpdateAccMsg{
 			ChannelID: test.NewRandomChannelID(rng),
 			Version:   uint64(rng.Int63()),
 			Sig:       sig,
@@ -97,7 +97,7 @@ func TestChannelUpdateAccSerialization(t *testing.T) {
 func TestChannelUpdateRejSerialization(t *testing.T) {
 	rng := pkgtest.Prng(t)
 	for i := 0; i < 4; i++ {
-		m := &msgChannelUpdateRej{
+		m := &ChannelUpdateRejMsg{
 			ChannelID: test.NewRandomChannelID(rng),
 			Version:   uint64(rng.Int63()),
 			Reason:    newRandomString(rng, 16, 16),

--- a/client/virtual_channel.go
+++ b/client/virtual_channel.go
@@ -36,7 +36,7 @@ func (c *Channel) IsVirtualChannel() bool {
 	return c.Parent() != nil && !c.equalParticipants(c.Parent())
 }
 
-func (c *Client) fundVirtualChannel(ctx context.Context, virtual *Channel, prop *VirtualChannelProposal) error {
+func (c *Client) fundVirtualChannel(ctx context.Context, virtual *Channel, prop *VirtualChannelProposalMsg) error {
 	parentID := prop.Parents[virtual.Idx()]
 	parent, ok := c.channels.Channel(parentID)
 	if !ok {

--- a/client/virtual_channel.go
+++ b/client/virtual_channel.go
@@ -63,9 +63,9 @@ func (c *Channel) proposeVirtualChannelFunding(ctx context.Context, virtual *Cha
 	state.Allocation.Balances = state.Allocation.Balances.Sub(balances)
 	state.AddSubAlloc(*channel.NewSubAlloc(virtual.ID(), balances.Sum(), indexMap))
 
-	err := c.updateGeneric(ctx, state, func(mcu *msgChannelUpdate) wire.Msg {
-		return &virtualChannelFundingProposal{
-			msgChannelUpdate: *mcu,
+	err := c.updateGeneric(ctx, state, func(mcu *ChannelUpdateMsg) wire.Msg {
+		return &VirtualChannelFundingProposalMsg{
+			ChannelUpdateMsg: *mcu,
 			Initial: channel.SignedState{
 				Params: virtual.Params(),
 				State:  virtual.State(),
@@ -85,7 +85,7 @@ const (
 
 func (c *Client) handleVirtualChannelFundingProposal(
 	ch *Channel,
-	prop *virtualChannelFundingProposal,
+	prop *VirtualChannelFundingProposalMsg,
 	responder *UpdateResponder,
 ) {
 	err := c.validateVirtualChannelFundingProposal(ch, prop)
@@ -236,7 +236,7 @@ func (c *Channel) pushVirtualUpdate(ctx context.Context, state *channel.State, s
 
 func (c *Client) validateVirtualChannelFundingProposal(
 	ch *Channel,
-	prop *virtualChannelFundingProposal,
+	prop *VirtualChannelFundingProposalMsg,
 ) error {
 	switch {
 	case prop.Initial.Params.ID() != prop.Initial.State.ID:
@@ -354,11 +354,11 @@ func (c *Client) matchFundingProposal(ctx context.Context, a, b interface{}) boo
 	return true
 }
 
-func castToFundingProposals(inputs ...interface{}) ([]*virtualChannelFundingProposal, error) {
+func castToFundingProposals(inputs ...interface{}) ([]*VirtualChannelFundingProposalMsg, error) {
 	var ok bool
-	props := make([]*virtualChannelFundingProposal, len(inputs))
+	props := make([]*VirtualChannelFundingProposalMsg, len(inputs))
 	for i, x := range inputs {
-		props[i], ok = x.(*virtualChannelFundingProposal)
+		props[i], ok = x.(*VirtualChannelFundingProposalMsg)
 		if !ok {
 			return nil, errors.Errorf("casting %d", i)
 		}
@@ -366,7 +366,7 @@ func castToFundingProposals(inputs ...interface{}) ([]*virtualChannelFundingProp
 	return props, nil
 }
 
-func (c *Client) gatherChannels(props ...*virtualChannelFundingProposal) ([]*Channel, error) {
+func (c *Client) gatherChannels(props ...*VirtualChannelFundingProposalMsg) ([]*Channel, error) {
 	var err error
 	channels := make([]*Channel, len(props))
 	for i, prop := range props {

--- a/client/virtual_channel_settlement.go
+++ b/client/virtual_channel_settlement.go
@@ -53,9 +53,9 @@ func (c *Channel) withdrawVirtualChannel(ctx context.Context, virtual *Channel) 
 		c.Log().WithError(err).Panicf("removing sub-allocation with id %x", virtualAlloc.ID)
 	}
 
-	err := c.updateGeneric(ctx, state, func(mcu *msgChannelUpdate) wire.Msg {
-		return &virtualChannelSettlementProposal{
-			msgChannelUpdate: *mcu,
+	err := c.updateGeneric(ctx, state, func(mcu *ChannelUpdateMsg) wire.Msg {
+		return &VirtualChannelSettlementProposalMsg{
+			ChannelUpdateMsg: *mcu,
 			Final: channel.SignedState{
 				Params: virtual.Params(),
 				State:  virtual.state(),
@@ -68,13 +68,13 @@ func (c *Channel) withdrawVirtualChannel(ctx context.Context, virtual *Channel) 
 }
 
 type proposalAndResponder struct {
-	prop *virtualChannelSettlementProposal
+	prop *VirtualChannelSettlementProposalMsg
 	resp *UpdateResponder
 }
 
 func (c *Client) handleVirtualChannelSettlementProposal(
 	parent *Channel,
-	prop *virtualChannelSettlementProposal,
+	prop *VirtualChannelSettlementProposalMsg,
 	responder *UpdateResponder,
 ) {
 	err := c.validateVirtualChannelSettlementProposal(parent, prop)
@@ -96,7 +96,7 @@ func (c *Client) handleVirtualChannelSettlementProposal(
 
 func (c *Client) validateVirtualChannelSettlementProposal(
 	parent *Channel,
-	prop *virtualChannelSettlementProposal,
+	prop *VirtualChannelSettlementProposalMsg,
 ) error {
 	// Validate parameters.
 	if prop.Final.Params.ID() != prop.Final.State.ID {
@@ -156,7 +156,7 @@ func (c *Client) matchSettlementProposal(ctx context.Context, a, b interface{}) 
 
 	// Cast.
 	inputs := []interface{}{a, b}
-	props := make([]*virtualChannelSettlementProposal, len(inputs))
+	props := make([]*VirtualChannelSettlementProposalMsg, len(inputs))
 	resps := make([]*UpdateResponder, len(inputs))
 	for i, x := range inputs {
 		pr, ok := x.(*proposalAndResponder)

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -161,7 +161,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	_channelsIngrid := make(chan *client.Channel, 1)
 	var openingProposalHandlerIngrid client.ProposalHandlerFunc = func(cp client.ChannelProposal, pr *client.ProposalResponder) {
 		switch cp := cp.(type) {
-		case *client.LedgerChannelProposal:
+		case *client.LedgerChannelProposalMsg:
 			ch, err := pr.Accept(ctx, cp.Accept(ingrid.Identity.Address(), client.WithRandomNonce()))
 			if err != nil {
 				vct.errs <- errors.WithMessage(err, "accepting ledger channel proposal")
@@ -223,7 +223,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 		cp client.ChannelProposal, pr *client.ProposalResponder,
 	) {
 		switch cp := cp.(type) {
-		case *client.VirtualChannelProposal:
+		case *client.VirtualChannelProposalMsg:
 			ch, err := pr.Accept(ctx, cp.Accept(bob.Identity.Address()))
 			if err != nil {
 				vct.errs <- errors.WithMessage(err, "accepting virtual channel proposal")


### PR DESCRIPTION
- Consistently use the pattern `<message-name>Msg` for all message types.

- Export the unexported message types, so that newer wire serialization adapters can define functions for serializing/de-serializing these messages.

Closes #302

