### PR TITLE
:boom: Channel.Update/ForceUpdate: updater no longer returns error

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ func main() {
 	}()
 
 	// send a channel update request to the other channel peer(s)
-	err = ch.Update(ctx, func(s *channel.State) error {
+	err = ch.Update(ctx, func(s *channel.State) {
 		// update state s, e.g., moving funds or changing app data
 	})
 	if err != nil { /* handle error */ }

--- a/channel/machine.go
+++ b/channel/machine.go
@@ -475,7 +475,7 @@ func (m *machine) expect(tr PhaseTransition) error {
 	return nil
 }
 
-// validTransition checks that the transition from the current to the provided
+// ValidTransition checks that the transition from the current to the provided
 // state is valid. The following checks are run:
 // * matching channel ids
 // * no transition from final state
@@ -483,7 +483,7 @@ func (m *machine) expect(tr PhaseTransition) error {
 // * preservation of balances
 // A StateMachine will additionally check the validity of the app-specific
 // transition whereas an ActionMachine checks each Action as being valid.
-func (m *machine) validTransition(to *State) error {
+func (m *machine) ValidTransition(to *State) error {
 	if to.ID != m.params.id {
 		return errors.New("new state's ID doesn't match")
 	}

--- a/channel/statemachine.go
+++ b/channel/statemachine.go
@@ -134,7 +134,7 @@ func (m *StateMachine) validTransition(to *State, actor Index) (err error) {
 	if actor >= m.N() {
 		return errors.New("actor index is out of range")
 	}
-	if err := m.machine.validTransition(to); err != nil {
+	if err := m.machine.ValidTransition(to); err != nil {
 		return err
 	}
 

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -210,6 +210,11 @@ func (c *Channel) ForceUpdate(ctx context.Context, updater func(*channel.State))
 	updater(state)
 	state.Version++
 
+	// Check state transition.
+	if err := c.machine.ValidTransition(state); err != nil {
+		return errors.WithMessage(err, "validating state transition")
+	}
+
 	// Apply state in machine and generate signature
 	if err := c.machine.SetProgressing(ctx, state); err != nil {
 		return errors.WithMessage(err, "updating machine")

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -178,16 +178,19 @@ func (c *Channel) registerDispute(ctx context.Context) error {
 	return nil
 }
 
-// ForceUpdate enforces a channel update on the adjudicator. `update` gets as
-// input a copy of the current state and is expected to modify the state as
-// intended. It should not to increment the version number as this is
-// automatically.
+// ForceUpdate enforces a state update through the adjudicator as specified by
+// the `updater` function.
+//
+// The updater function must adhere to the following rules:
+// - The version must not be changed. It is incremented automatically.
+// - The assets must not be changed.
+// - The locked allocation must not be changed.
 //
 // Returns TxTimedoutError when the program times out waiting for a transaction
 // to be mined. Returns ChainNotReachableError if the connection to the
 // blockchain network fails when sending a transaction to / reading from the
 // blockchain.
-func (c *Channel) ForceUpdate(ctx context.Context, update func(*channel.State) error) error {
+func (c *Channel) ForceUpdate(ctx context.Context, updater func(*channel.State)) error {
 	err := c.ensureRegistered(ctx)
 	if err != nil {
 		return err
@@ -204,11 +207,8 @@ func (c *Channel) ForceUpdate(ctx context.Context, update func(*channel.State) e
 
 	// Update state
 	state := ar.Tx.State.Clone()
+	updater(state)
 	state.Version++
-	err = update(state)
-	if err != nil {
-		return errors.WithMessage(err, "updating state")
-	}
 
 	// Apply state in machine and generate signature
 	if err := c.machine.SetProgressing(ctx, state); err != nil {

--- a/client/test/progression.go
+++ b/client/test/progression.go
@@ -95,14 +95,13 @@ func (r *Paul) exec(_cfg ExecConfig, ch *paymentChannel) {
 	r.waitStage() // wait for setup complete
 
 	// progress
-	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) error {
+	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) {
 		bal := func(user channel.Index) int64 {
 			return s.Balances[assetIdx][user].Int64()
 		}
 		half := (bal(0) + bal(1)) / 2 //nolint:gomnd
 		s.Balances[assetIdx][0] = big.NewInt(half)
 		s.Balances[assetIdx][1] = big.NewInt(half)
-		return nil
 	}))
 
 	// await our progression confirmation
@@ -167,14 +166,13 @@ func (r *Paula) exec(_cfg ExecConfig, ch *paymentChannel, _ *acceptNextPropHandl
 	r.t.Logf("%v received progression confirmation 1", r.setup.Name)
 
 	// we progress
-	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) error {
+	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) {
 		bal := func(user channel.Index) int64 {
 			return s.Balances[assetIdx][user].Int64()
 		}
 		half := (bal(0) + bal(1)) / 2 //nolint:gomnd
 		s.Balances[assetIdx][0] = big.NewInt(half + paulPaulaBalTransferAmount)
 		s.Balances[assetIdx][1] = big.NewInt(half - paulPaulaBalTransferAmount)
-		return nil
 	}))
 
 	// await our progression confirmation

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -268,15 +268,13 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 		t.Fatalf("Error in go-routine: %v", err)
 	}
 
-	err = vct.chAliceBob.Update(ctx, func(s *channel.State) error {
+	err = vct.chAliceBob.Update(ctx, func(s *channel.State) {
 		s.Balances = channel.Balances{vct.virtualBalsUpdated}
-		return nil
 	})
 	require.NoError(err, "updating virtual channel")
 
-	err = vct.chAliceBob.Update(ctx, func(s *channel.State) error {
+	err = vct.chAliceBob.Update(ctx, func(s *channel.State) {
 		s.IsFinal = true
-		return nil
 	})
 	require.NoError(err, "updating virtual channel")
 	return vct


### PR DESCRIPTION
Related to #155 

Instead of changing the API drastically, improve documentation.