### PR TITLE
Refactor message serialization tests

### DIFF
--- a/client/proposalmsgs_test.go
+++ b/client/proposalmsgs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 package client_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,11 +24,13 @@ import (
 	"perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
-	wallettest "perun.network/go-perun/wallet/test"
-	"perun.network/go-perun/wire"
 	peruniotest "perun.network/go-perun/wire/perunio/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
+
+func TestProposalMsgsSerialization(t *testing.T) {
+	clienttest.ProposalMsgsSerializationTest(t, peruniotest.MsgSerializerTest)
+}
 
 func TestNewLedgerChannelProposal(t *testing.T) {
 	rng := pkgtest.Prng(t)
@@ -49,31 +50,6 @@ func TestNewLedgerChannelProposal(t *testing.T) {
 	agreement = test.NewRandomBalances(rng, test.WithNumAssets(len(base.InitBals.Assets)))
 	_, err = client.NewLedgerChannelProposal(base.ChallengeDuration, base.Participant, base.InitBals, base.Peers, client.WithFundingAgreement(agreement))
 	assert.EqualError(t, err, "FundingAgreement and initial balances differ")
-}
-
-func TestChannelProposalReqSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 16; i++ {
-		var (
-			app client.ProposalOpts
-			m   wire.Msg
-			err error
-		)
-		if i&1 == 0 {
-			app = client.WithApp(test.NewRandomAppAndData(rng))
-		}
-		switch i % 3 {
-		case 0:
-			m = clienttest.NewRandomLedgerChannelProposal(rng, client.WithNonceFrom(rng), app)
-		case 1:
-			m, err = clienttest.NewRandomSubChannelProposal(rng, client.WithNonceFrom(rng), app)
-			require.NoError(t, err)
-		case 2:
-			m, err = clienttest.NewRandomVirtualChannelProposal(rng, client.WithNonceFrom(rng), app)
-			require.NoError(t, err)
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
 }
 
 func TestLedgerChannelProposalReqProposalID(t *testing.T) {
@@ -110,69 +86,4 @@ func TestVirtualChannelProposalReqProposalID(t *testing.T) {
 	assert.Equal(t, channel.NoData(), fake.InitData, "virtual channel should always has no data")
 
 	assert.NotEqual(t, original.ProposalID, fake.ProposalID)
-}
-
-func TestChannelProposalAccSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	t.Run("ledger channel", func(t *testing.T) {
-		for i := 0; i < 16; i++ {
-			proposal := clienttest.NewRandomLedgerChannelProposal(rng)
-			m := proposal.Accept(
-				wallettest.NewRandomAddress(rng),
-				client.WithNonceFrom(rng))
-			peruniotest.MsgSerializerTest(t, m)
-		}
-	})
-	t.Run("sub channel", func(t *testing.T) {
-		for i := 0; i < 16; i++ {
-			var err error
-			proposal, err := clienttest.NewRandomSubChannelProposal(rng)
-			require.NoError(t, err)
-			m := proposal.Accept(client.WithNonceFrom(rng))
-			peruniotest.MsgSerializerTest(t, m)
-		}
-	})
-	t.Run("virtual channel", func(t *testing.T) {
-		for i := 0; i < 16; i++ {
-			var err error
-			proposal, err := clienttest.NewRandomVirtualChannelProposal(rng)
-			require.NoError(t, err)
-			m := proposal.Accept(wallettest.NewRandomAddress(rng))
-			peruniotest.MsgSerializerTest(t, m)
-		}
-	})
-}
-
-func TestChannelProposalRejSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 16; i++ {
-		m := &client.ChannelProposalRejMsg{
-			ProposalID: newRandomProposalID(rng),
-			Reason:     newRandomString(rng, 16, 16),
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
-}
-
-func TestSubChannelProposalSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	const repeatRandomizedTest = 16
-	for i := 0; i < repeatRandomizedTest; i++ {
-		prop, err := clienttest.NewRandomSubChannelProposal(rng)
-		require.NoError(t, err)
-		peruniotest.MsgSerializerTest(t, prop)
-	}
-}
-
-func newRandomProposalID(rng *rand.Rand) (id client.ProposalID) {
-	rng.Read(id[:])
-	return
-}
-
-// newRandomstring returns a random string of length between minLen and
-// minLen+maxLenDiff.
-func newRandomString(rng *rand.Rand, minLen, maxLenDiff int) string {
-	r := make([]byte, minLen+rng.Intn(maxLenDiff))
-	rng.Read(r)
-	return string(r)
 }

--- a/client/syncmsgs_test.go
+++ b/client/syncmsgs_test.go
@@ -17,24 +17,10 @@ package client_test
 import (
 	"testing"
 
-	"perun.network/go-perun/channel"
-	"perun.network/go-perun/channel/test"
-	"perun.network/go-perun/client"
+	clienttest "perun.network/go-perun/client/test"
 	peruniotest "perun.network/go-perun/wire/perunio/test"
-	pkgtest "polycry.pt/poly-go/test"
 )
 
 func TestChannelSyncSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 4; i++ {
-		state := test.NewRandomState(rng)
-		m := &client.ChannelSyncMsg{
-			Phase: channel.Phase(rng.Intn(channel.LastPhase)),
-			CurrentTX: channel.Transaction{
-				State: state,
-				Sigs:  newRandomSigs(rng, state.NumParts()),
-			},
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
+	clienttest.ChannelSyncMsgSerializationTest(t, peruniotest.MsgSerializerTest)
 }

--- a/client/test/proposalmsgs.go
+++ b/client/test/proposalmsgs.go
@@ -53,7 +53,7 @@ func channelProposalReqSerializationTest(t *testing.T, serializerTest func(t *te
 		case 1:
 			m, err = NewRandomSubChannelProposal(rng, client.WithNonceFrom(rng), app)
 			require.NoError(t, err)
-		case 2:
+		case 2: //nolint: gomnd 	// This is not a magic number.
 			m, err = NewRandomVirtualChannelProposal(rng, client.WithNonceFrom(rng), app)
 			require.NoError(t, err)
 		}
@@ -93,11 +93,13 @@ func channelProposalAccSerializationTest(t *testing.T, serializerTest func(t *te
 
 func channelProposalRejSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
 	t.Helper()
+	minLen := 16
+	maxLenDiff := 16
 	rng := pkgtest.Prng(t)
 	for i := 0; i < 16; i++ {
 		m := &client.ChannelProposalRejMsg{
 			ProposalID: newRandomProposalID(rng),
-			Reason:     newRandomString(rng, 16, 16),
+			Reason:     newRandomString(rng, minLen, maxLenDiff),
 		}
 		serializerTest(t, m)
 	}

--- a/client/test/proposalmsgs.go
+++ b/client/test/proposalmsgs.go
@@ -1,0 +1,117 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"perun.network/go-perun/channel/test"
+	"perun.network/go-perun/client"
+	wallettest "perun.network/go-perun/wallet/test"
+	"perun.network/go-perun/wire"
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+// ProposalMsgsSerializationTest runs serialization tests on proposal messages.
+func ProposalMsgsSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	channelProposalReqSerializationTest(t, serializerTest)
+	channelProposalAccSerializationTest(t, serializerTest)
+	channelProposalRejSerializationTest(t, serializerTest)
+}
+
+func channelProposalReqSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 16; i++ {
+		var (
+			app client.ProposalOpts
+			m   wire.Msg
+			err error
+		)
+		if i&1 == 0 {
+			app = client.WithApp(test.NewRandomAppAndData(rng))
+		}
+		switch i % 3 {
+		case 0:
+			m = NewRandomLedgerChannelProposal(rng, client.WithNonceFrom(rng), app)
+		case 1:
+			m, err = NewRandomSubChannelProposal(rng, client.WithNonceFrom(rng), app)
+			require.NoError(t, err)
+		case 2:
+			m, err = NewRandomVirtualChannelProposal(rng, client.WithNonceFrom(rng), app)
+			require.NoError(t, err)
+		}
+		serializerTest(t, m)
+	}
+}
+
+func channelProposalAccSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	t.Run("ledger channel", func(t *testing.T) {
+		for i := 0; i < 16; i++ {
+			proposal := NewRandomLedgerChannelProposal(rng)
+			m := proposal.Accept(wallettest.NewRandomAddress(rng), client.WithNonceFrom(rng))
+			serializerTest(t, m)
+		}
+	})
+	t.Run("sub channel", func(t *testing.T) {
+		for i := 0; i < 16; i++ {
+			var err error
+			proposal, err := NewRandomSubChannelProposal(rng)
+			require.NoError(t, err)
+			m := proposal.Accept(client.WithNonceFrom(rng))
+			serializerTest(t, m)
+		}
+	})
+	t.Run("virtual channel", func(t *testing.T) {
+		for i := 0; i < 16; i++ {
+			var err error
+			proposal, err := NewRandomVirtualChannelProposal(rng)
+			require.NoError(t, err)
+			m := proposal.Accept(wallettest.NewRandomAddress(rng))
+			serializerTest(t, m)
+		}
+	})
+}
+
+func channelProposalRejSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 16; i++ {
+		m := &client.ChannelProposalRejMsg{
+			ProposalID: newRandomProposalID(rng),
+			Reason:     newRandomString(rng, 16, 16),
+		}
+		serializerTest(t, m)
+	}
+}
+
+func newRandomProposalID(rng *rand.Rand) (id client.ProposalID) {
+	rng.Read(id[:])
+	return
+}
+
+// newRandomstring returns a random ascii string of length between minLen and
+// minLen+maxLenDiff.
+func newRandomString(rng *rand.Rand, minLen, maxLenDiff int) string {
+	r := make([]byte, minLen+rng.Intn(maxLenDiff))
+	rng.Read(r)
+	return string(r)
+}

--- a/client/test/syncmsgs.go
+++ b/client/test/syncmsgs.go
@@ -1,0 +1,42 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"perun.network/go-perun/channel"
+	"perun.network/go-perun/channel/test"
+	"perun.network/go-perun/client"
+	"perun.network/go-perun/wire"
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+// ChannelSyncMsgSerializationTest runs serialization tests on channel sync messages.
+func ChannelSyncMsgSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 4; i++ {
+		state := test.NewRandomState(rng)
+		m := &client.ChannelSyncMsg{
+			Phase: channel.Phase(rng.Intn(channel.LastPhase)),
+			CurrentTX: channel.Transaction{
+				State: state,
+				Sigs:  newRandomSigs(rng, state.NumParts()),
+			},
+		}
+		serializerTest(t, m)
+	}
+}

--- a/client/test/updatemsgs.go
+++ b/client/test/updatemsgs.go
@@ -1,0 +1,152 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"math/rand"
+	"testing"
+
+	"perun.network/go-perun/channel"
+	"perun.network/go-perun/channel/test"
+	"perun.network/go-perun/client"
+	"perun.network/go-perun/wallet"
+	wallettest "perun.network/go-perun/wallet/test"
+	"perun.network/go-perun/wire"
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+// UpdateMsgsSerializationTest runs serialization tests on update messages.
+func UpdateMsgsSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	channelUpdateSerializationTest(t, serializerTest)
+	virtualChannelFundingProposalSerializationTest(t, serializerTest)
+	virtualChannelSettlementProposalSerializationTest(t, serializerTest)
+	channelUpdateAccSerializationTest(t, serializerTest)
+	channelUpdateRejSerializationTest(t, serializerTest)
+}
+
+func channelUpdateSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg),
+) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 4; i++ {
+		m := newRandomMsgChannelUpdate(rng)
+		serializerTest(t, m)
+	}
+}
+
+func virtualChannelFundingProposalSerializationTest(
+	t *testing.T,
+	serializerTest func(t *testing.T, msg wire.Msg),
+) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 4; i++ {
+		msgUp := newRandomMsgChannelUpdate(rng)
+		params, state := test.NewRandomParamsAndState(rng)
+		m := &client.VirtualChannelFundingProposalMsg{
+			ChannelUpdateMsg: *msgUp,
+			Initial: channel.SignedState{
+				Params: params,
+				State:  state,
+				Sigs:   newRandomSigs(rng, state.NumParts()),
+			},
+			IndexMap: test.NewRandomIndexMap(rng, state.NumParts(), msgUp.State.NumParts()),
+		}
+		serializerTest(t, m)
+	}
+}
+
+func virtualChannelSettlementProposalSerializationTest(
+	t *testing.T,
+	serializerTest func(t *testing.T, msg wire.Msg),
+) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 4; i++ {
+		msgUp := newRandomMsgChannelUpdate(rng)
+		params, state := test.NewRandomParamsAndState(rng)
+		m := &client.VirtualChannelSettlementProposalMsg{
+			ChannelUpdateMsg: *msgUp,
+			Final: channel.SignedState{
+				Params: params,
+				State:  state,
+				Sigs:   newRandomSigs(rng, state.NumParts()),
+			},
+		}
+		serializerTest(t, m)
+	}
+}
+
+func channelUpdateAccSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 4; i++ {
+		sig := newRandomSig(rng)
+		m := &client.ChannelUpdateAccMsg{
+			ChannelID: test.NewRandomChannelID(rng),
+			Version:   uint64(rng.Int63()),
+			Sig:       sig,
+		}
+		serializerTest(t, m)
+	}
+}
+
+func channelUpdateRejSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+	rng := pkgtest.Prng(t)
+	for i := 0; i < 4; i++ {
+		m := &client.ChannelUpdateRejMsg{
+			ChannelID: test.NewRandomChannelID(rng),
+			Version:   uint64(rng.Int63()),
+			Reason:    newRandomString(rng, 16, 16),
+		}
+		serializerTest(t, m)
+	}
+}
+
+func newRandomMsgChannelUpdate(rng *rand.Rand) *client.ChannelUpdateMsg {
+	state := test.NewRandomState(rng)
+	sig := newRandomSig(rng)
+	return &client.ChannelUpdateMsg{
+		ChannelUpdate: client.ChannelUpdate{
+			State:    state,
+			ActorIdx: channel.Index(rng.Intn(state.NumParts())),
+		},
+		Sig: sig,
+	}
+}
+
+// newRandomSig generates a random account and then returns the signature on
+// some random data.
+func newRandomSig(rng *rand.Rand) wallet.Sig {
+	acc := wallettest.NewRandomAccount(rng)
+	data := make([]byte, 8)
+	rng.Read(data)
+	sig, err := acc.SignData(data)
+	if err != nil {
+		panic("signing error")
+	}
+	return sig
+}
+
+// newRandomSigs generates a list of random signatures.
+func newRandomSigs(rng *rand.Rand, n int) (a []wallet.Sig) {
+	a = make([]wallet.Sig, n)
+	for i := range a {
+		a[i] = newRandomSig(rng)
+	}
+	return
+}

--- a/client/test/updatemsgs.go
+++ b/client/test/updatemsgs.go
@@ -107,11 +107,13 @@ func channelUpdateAccSerializationTest(t *testing.T, serializerTest func(t *test
 func channelUpdateRejSerializationTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
 	t.Helper()
 	rng := pkgtest.Prng(t)
+	minLen := 16
+	maxLenDiff := 16
 	for i := 0; i < 4; i++ {
 		m := &client.ChannelUpdateRejMsg{
 			ChannelID: test.NewRandomChannelID(rng),
 			Version:   uint64(rng.Int63()),
-			Reason:    newRandomString(rng, 16, 16),
+			Reason:    newRandomString(rng, minLen, maxLenDiff),
 		}
 		serializerTest(t, m)
 	}
@@ -133,7 +135,8 @@ func newRandomMsgChannelUpdate(rng *rand.Rand) *client.ChannelUpdateMsg {
 // some random data.
 func newRandomSig(rng *rand.Rand) wallet.Sig {
 	acc := wallettest.NewRandomAccount(rng)
-	data := make([]byte, 8)
+	maxLenOfData := 256
+	data := make([]byte, rng.Intn(maxLenOfData))
 	rng.Read(data)
 	sig, err := acc.SignData(data)
 	if err != nil {

--- a/client/updatemsgs_test.go
+++ b/client/updatemsgs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,117 +15,12 @@
 package client_test
 
 import (
-	"math/rand"
 	"testing"
 
-	"perun.network/go-perun/channel"
-	"perun.network/go-perun/channel/test"
-	"perun.network/go-perun/client"
-	"perun.network/go-perun/wallet"
-	wallettest "perun.network/go-perun/wallet/test"
+	clienttest "perun.network/go-perun/client/test"
 	peruniotest "perun.network/go-perun/wire/perunio/test"
-	pkgtest "polycry.pt/poly-go/test"
 )
 
-func TestChannelUpdateSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 4; i++ {
-		m := newRandomMsgChannelUpdate(rng)
-		peruniotest.MsgSerializerTest(t, m)
-	}
-}
-
-func newRandomMsgChannelUpdate(rng *rand.Rand) *client.ChannelUpdateMsg {
-	state := test.NewRandomState(rng)
-	sig := newRandomSig(rng)
-	return &client.ChannelUpdateMsg{
-		ChannelUpdate: client.ChannelUpdate{
-			State:    state,
-			ActorIdx: channel.Index(rng.Intn(state.NumParts())),
-		},
-		Sig: sig,
-	}
-}
-
-func TestSerialization_VirtualChannelFundingProposal(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 4; i++ {
-		msgUp := newRandomMsgChannelUpdate(rng)
-		params, state := test.NewRandomParamsAndState(rng)
-		m := &client.VirtualChannelFundingProposalMsg{
-			ChannelUpdateMsg: *msgUp,
-			Initial: channel.SignedState{
-				Params: params,
-				State:  state,
-				Sigs:   newRandomSigs(rng, state.NumParts()),
-			},
-			IndexMap: test.NewRandomIndexMap(rng, state.NumParts(), msgUp.State.NumParts()),
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
-}
-
-func TestSerialization_VirtualChannelSettlementProposal(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 4; i++ {
-		msgUp := newRandomMsgChannelUpdate(rng)
-		params, state := test.NewRandomParamsAndState(rng)
-		m := &client.VirtualChannelSettlementProposalMsg{
-			ChannelUpdateMsg: *msgUp,
-			Final: channel.SignedState{
-				Params: params,
-				State:  state,
-				Sigs:   newRandomSigs(rng, state.NumParts()),
-			},
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
-}
-
-func TestChannelUpdateAccSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 4; i++ {
-		sig := newRandomSig(rng)
-		m := &client.ChannelUpdateAccMsg{
-			ChannelID: test.NewRandomChannelID(rng),
-			Version:   uint64(rng.Int63()),
-			Sig:       sig,
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
-}
-
-func TestChannelUpdateRejSerialization(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	for i := 0; i < 4; i++ {
-		m := &client.ChannelUpdateRejMsg{
-			ChannelID: test.NewRandomChannelID(rng),
-			Version:   uint64(rng.Int63()),
-			Reason:    "random-string",
-			// Reason:    newRandomString(rng, 16, 16),
-		}
-		peruniotest.MsgSerializerTest(t, m)
-	}
-}
-
-// newRandomSig generates a random account and then returns the signature on
-// some random data.
-func newRandomSig(rng *rand.Rand) wallet.Sig {
-	acc := wallettest.NewRandomAccount(rng)
-	data := make([]byte, 8)
-	rng.Read(data)
-	sig, err := acc.SignData(data)
-	if err != nil {
-		panic("signing error")
-	}
-	return sig
-}
-
-// newRandomSigs generates a list of random signatures.
-func newRandomSigs(rng *rand.Rand, n int) (a []wallet.Sig) {
-	a = make([]wallet.Sig, n)
-	for i := range a {
-		a[i] = newRandomSig(rng)
-	}
-	return
+func Test_UpdateMsgsSerialization(t *testing.T) {
+	clienttest.UpdateMsgsSerializationTest(t, peruniotest.MsgSerializerTest)
 }

--- a/client/updatemsgs_test.go
+++ b/client/updatemsgs_test.go
@@ -101,7 +101,8 @@ func TestChannelUpdateRejSerialization(t *testing.T) {
 		m := &client.ChannelUpdateRejMsg{
 			ChannelID: test.NewRandomChannelID(rng),
 			Version:   uint64(rng.Int63()),
-			Reason:    newRandomString(rng, 16, 16),
+			Reason:    "random-string",
+			// Reason:    newRandomString(rng, 16, 16),
 		}
 		peruniotest.MsgSerializerTest(t, m)
 	}

--- a/wire/account_test.go
+++ b/wire/account_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,10 @@ import (
 	"testing"
 
 	_ "perun.network/go-perun/backend/ethereum/wallet/test" // random init
-	wallettest "perun.network/go-perun/wallet/test"
-	"perun.network/go-perun/wire"
 	peruniotest "perun.network/go-perun/wire/perunio/test"
-	pkgtest "polycry.pt/poly-go/test"
+	wiretest "perun.network/go-perun/wire/test"
 )
 
 func TestAuthResponseMsg(t *testing.T) {
-	rng := pkgtest.Prng(t)
-	peruniotest.MsgSerializerTest(t, wire.NewAuthResponseMsg(wallettest.NewRandomAccount(rng)))
+	wiretest.AuthMsgsTest(t, peruniotest.MsgSerializerTest)
 }

--- a/wire/controlmsgs_test.go
+++ b/wire/controlmsgs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,18 +17,10 @@ package wire_test
 import (
 	"testing"
 
-	"perun.network/go-perun/wire"
 	peruniotest "perun.network/go-perun/wire/perunio/test"
+	wiretest "perun.network/go-perun/wire/test"
 )
 
-func TestPingMsg(t *testing.T) {
-	peruniotest.MsgSerializerTest(t, wire.NewPingMsg())
-}
-
-func TestPongMsg(t *testing.T) {
-	peruniotest.MsgSerializerTest(t, wire.NewPongMsg())
-}
-
-func TestShutdownMsg(t *testing.T) {
-	peruniotest.MsgSerializerTest(t, &wire.ShutdownMsg{"m2384ordkln fb30954390582"})
+func TestControlMsgs(t *testing.T) {
+	wiretest.ControlMsgsTest(t, peruniotest.MsgSerializerTest)
 }

--- a/wire/test/msgstest.go
+++ b/wire/test/msgstest.go
@@ -1,0 +1,50 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"math/rand"
+	"testing"
+
+	wallettest "perun.network/go-perun/wallet/test"
+	"perun.network/go-perun/wire"
+
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+// ControlMsgsTest runs serialization tests on control messages.
+func ControlMsgsTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+
+	serializerTest(t, wire.NewPingMsg())
+	serializerTest(t, wire.NewPongMsg())
+	serializerTest(t, &wire.ShutdownMsg{Reason: "m2384ordkln fb30954390582"})
+}
+
+// AuthMsgsTest runs serialization tests on auth message.
+func AuthMsgsTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
+	t.Helper()
+
+	rng := pkgtest.Prng(t)
+	serializerTest(t, wire.NewAuthResponseMsg(wallettest.NewRandomAccount(rng)))
+}
+
+// newRandomstring returns a random ascii string of length between minLen and
+// minLen+maxLenDiff.
+func newRandomString(rng *rand.Rand, minLen, maxLenDiff int) string {
+	r := make([]byte, minLen+rng.Intn(maxLenDiff))
+	rng.Read(r)
+	return string(r)
+}

--- a/wire/test/msgstest.go
+++ b/wire/test/msgstest.go
@@ -28,10 +28,12 @@ import (
 func ControlMsgsTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
 	t.Helper()
 
-	rng := pkgtest.Prng(t)
 	serializerTest(t, wire.NewPingMsg())
 	serializerTest(t, wire.NewPongMsg())
-	serializerTest(t, &wire.ShutdownMsg{Reason: newRandomString(rng, 16, 16)})
+	minLen := 16
+	maxLenDiff := 16
+	rng := pkgtest.Prng(t)
+	serializerTest(t, &wire.ShutdownMsg{Reason: newRandomString(rng, minLen, maxLenDiff)})
 }
 
 // AuthMsgsTest runs serialization tests on auth message.

--- a/wire/test/msgstest.go
+++ b/wire/test/msgstest.go
@@ -28,9 +28,10 @@ import (
 func ControlMsgsTest(t *testing.T, serializerTest func(t *testing.T, msg wire.Msg)) {
 	t.Helper()
 
+	rng := pkgtest.Prng(t)
 	serializerTest(t, wire.NewPingMsg())
 	serializerTest(t, wire.NewPongMsg())
-	serializerTest(t, &wire.ShutdownMsg{Reason: "m2384ordkln fb30954390582"})
+	serializerTest(t, &wire.ShutdownMsg{Reason: newRandomString(rng, 16, 16)})
 }
 
 // AuthMsgsTest runs serialization tests on auth message.


### PR DESCRIPTION
- Refactor the tests to use generic test functions.

- In preparation for extending these tests to newer wire serialization
  adapters.

- Also, use random string for reason field in shutdowm message test.
