### PR TITLE
Fix CI fails

### DIFF
--- a/backend/ethereum/channel/conclude_test.go
+++ b/backend/ethereum/channel/conclude_test.go
@@ -102,10 +102,13 @@ func TestAdjudicator_ConcludeWithSubChannels(t *testing.T) {
 	// 0. setup
 
 	const (
-		numParts               = 2
-		maxCountSubChannels    = 3
-		maxCountSubSubChannels = 3
-		maxChallengeDuration   = 3600
+		numParts                  = 2
+		maxCountSubChannels       = 3
+		maxCountSubSubChannels    = 3
+		minFundingTXBlocksTimeout = 200
+		minChallengeDuration      = minFundingTXBlocksTimeout
+		maxChallengeDuration      = 3600
+		challengeDurationSpread   = maxChallengeDuration - minChallengeDuration
 	)
 	ctx, cancel := newDefaultTestContext()
 	defer cancel()
@@ -121,7 +124,7 @@ func TestAdjudicator_ConcludeWithSubChannels(t *testing.T) {
 		accounts          = s.Accs
 		participants      = s.Parts
 		asset             = s.Asset
-		challengeDuration = uint64(rng.Intn(maxChallengeDuration))
+		challengeDuration = uint64(rng.Intn(challengeDurationSpread) + minChallengeDuration)
 		makeRandomChannel = func(rng *rand.Rand, ledger bool) paramsAndState {
 			return makeRandomChannel(rng, participants, asset, challengeDuration, ledger)
 		}

--- a/backend/ethereum/subscription/resistanteventsub.go
+++ b/backend/ethereum/subscription/resistanteventsub.go
@@ -257,8 +257,6 @@ func (s *ResistantEventSub) isFinal(event *Event) bool {
 // Close closes the sub and the underlying `EventSub`.
 // Can be called more than once. Is thread safe.
 func (s *ResistantEventSub) Close() {
-	if err := s.closer.Close(); err != nil && !pkgsync.IsAlreadyClosedError(err) {
-		log.WithError(err).Error("could not close EventSub")
-	}
+	s.closer.Close() // Silently ignore repeated close calls, as it is allowed in this function's specification.
 	// NOTE: The underlying `EventSub` is closed in the `OnCloseAlways` hook.
 }


### PR DESCRIPTION
* Stabilise reorg resistant subscription tests, although it does not cause the inherent problem that caused the tests to fail. Fixing that would be way more involved.
* Fix bug in Adjudicator test: challenge duration (is used as timeout for the funding transactions) was selected in *[0,3600)*, fixed to *[200,3600)* now, to guarantee enough time for funding.