### PR TITLE
Use LatestSigner and don't set GasPrice in ContractBackend

### DIFF
--- a/backend/ethereum/channel/contractbackend.go
+++ b/backend/ethereum/channel/contractbackend.go
@@ -145,11 +145,6 @@ func (c *ContractBackend) NewTransactor(ctx context.Context, gasLimit uint64,
 		return nil, errors.WithMessage(err, "creating transactor")
 	}
 
-	auth.GasPrice, err = c.SuggestGasPrice(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "estimating gas price")
-	}
-
 	auth.GasLimit = gasLimit
 	auth.Context = ctx
 

--- a/backend/ethereum/channel/contractbackend_test.go
+++ b/backend/ethereum/channel/contractbackend_test.go
@@ -32,6 +32,8 @@ import (
 	pkgtest "polycry.pt/poly-go/test"
 )
 
+const valueTxGas = 21_000
+
 func fromEthAddr(a common.Address) wallet.Address {
 	return (*ethwallet.Address)(&a)
 }
@@ -126,15 +128,14 @@ func Test_ConfirmTransaction(t *testing.T) {
 	defer cancel()
 
 	// Create the Transaction.
-	rawTx := types.NewTx(&types.LegacyTx{
-		Nonce:    0,
-		To:       &common.Address{},
-		Value:    big.NewInt(1),
-		Gas:      test.GasLimit,
-		GasPrice: big.NewInt(test.GasPrice),
-		Data:     nil,
+	rawTx := types.NewTx(&types.DynamicFeeTx{
+		Nonce:     0,
+		GasFeeCap: big.NewInt(test.InitialGasBaseFee),
+		Gas:       valueTxGas,
+		To:        &common.Address{},
+		Value:     big.NewInt(1),
 	})
-	opts, err := s.CB.NewTransactor(ctx, 1, s.TxSender.Account)
+	opts, err := s.CB.NewTransactor(ctx, valueTxGas, s.TxSender.Account)
 	require.NoError(t, err)
 	signed, err := opts.Signer(s.TxSender.Account.Address, rawTx)
 	require.NoError(t, err)

--- a/backend/ethereum/channel/contractbackend_test.go
+++ b/backend/ethereum/channel/contractbackend_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,8 +32,6 @@ import (
 	"perun.network/go-perun/wallet"
 	pkgtest "polycry.pt/poly-go/test"
 )
-
-const valueTxGas = 21_000
 
 func fromEthAddr(a common.Address) wallet.Address {
 	return (*ethwallet.Address)(&a)
@@ -131,11 +130,11 @@ func Test_ConfirmTransaction(t *testing.T) {
 	rawTx := types.NewTx(&types.DynamicFeeTx{
 		Nonce:     0,
 		GasFeeCap: big.NewInt(test.InitialGasBaseFee),
-		Gas:       valueTxGas,
+		Gas:       params.TxGas,
 		To:        &common.Address{},
 		Value:     big.NewInt(1),
 	})
-	opts, err := s.CB.NewTransactor(ctx, valueTxGas, s.TxSender.Account)
+	opts, err := s.CB.NewTransactor(ctx, params.TxGas, s.TxSender.Account)
 	require.NoError(t, err)
 	signed, err := opts.Signer(s.TxSender.Account.Address, rawTx)
 	require.NoError(t, err)

--- a/backend/ethereum/channel/funder_test.go
+++ b/backend/ethereum/channel/funder_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,7 +75,7 @@ func newFunderSetup(rng *rand.Rand) (
 	ksWallet := wallettest.RandomWallet().(*keystore.Wallet)
 	cb := ethchannel.NewContractBackend(
 		simBackend,
-		keystore.NewTransactor(*ksWallet, types.NewEIP155Signer(big.NewInt(1337))),
+		keystore.NewTransactor(*ksWallet, test.SimSigner),
 		TxFinalityDepth,
 	)
 	funder := ethchannel.NewFunder(cb)
@@ -396,7 +395,7 @@ func newNFunders(
 	simBackend.FundAddress(ctx, tokenAcc.Address)
 	cb := ethchannel.NewContractBackend(
 		simBackend,
-		keystore.NewTransactor(*ksWallet, types.NewEIP155Signer(big.NewInt(1337))),
+		keystore.NewTransactor(*ksWallet, test.SimSigner),
 		TxFinalityDepth,
 	)
 

--- a/backend/ethereum/channel/test/setup.go
+++ b/backend/ethereum/channel/test/setup.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
 	ethchannel "perun.network/go-perun/backend/ethereum/channel"
@@ -73,10 +71,9 @@ func NewSimSetup(t *testing.T, rng *rand.Rand, txFinalityDepth uint64, blockInte
 		t.Cleanup(simBackend.StopMining)
 	}
 
-	signer := types.NewEIP155Signer(params.AllEthashProtocolChanges.ChainID)
 	contractBackend := ethchannel.NewContractBackend(
 		simBackend,
-		keystore.NewTransactor(*ksWallet, signer),
+		keystore.NewTransactor(*ksWallet, SimSigner),
 		txFinalityDepth,
 	)
 
@@ -119,10 +116,9 @@ func NewSetup(t *testing.T, rng *rand.Rand, n int, blockInterval time.Duration, 
 		s.Parts[i] = s.Accs[i].Address()
 		s.SimBackend.FundAddress(ctx, s.Accs[i].Account.Address)
 		s.Recvs[i] = ksWallet.NewRandomAccount(rng).Address().(*ethwallet.Address)
-		signer := types.NewEIP155Signer(params.AllEthashProtocolChanges.ChainID)
 		cb := ethchannel.NewContractBackend(
 			s.SimBackend,
-			keystore.NewTransactor(*ksWallet, signer),
+			keystore.NewTransactor(*ksWallet, SimSigner),
 			txFinalityDepth,
 		)
 		s.Funders[i] = ethchannel.NewFunder(cb)

--- a/backend/ethereum/channel/test/simulated.go
+++ b/backend/ethereum/channel/test/simulated.go
@@ -106,11 +106,6 @@ func NewSimulatedBackend(opts ...SimBackendOpt) *SimulatedBackend {
 	return sb
 }
 
-// SuggestGasPrice always returns `GasPrice`.
-func (*SimulatedBackend) SuggestGasPrice(context.Context) (*big.Int, error) {
-	return big.NewInt(GasPrice), nil
-}
-
 // SendTransaction executes a transaction.
 func (s *SimulatedBackend) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	if err := s.SimulatedBackend.SendTransaction(ctx, tx); err != nil {

--- a/backend/ethereum/channel/test/simulated.go
+++ b/backend/ethereum/channel/test/simulated.go
@@ -126,7 +126,7 @@ func (s *SimulatedBackend) FundAddress(ctx context.Context, addr common.Address)
 	txdata := &types.DynamicFeeTx{
 		Nonce:     nonce,
 		GasFeeCap: big.NewInt(InitialGasBaseFee),
-		Gas:       21000,
+		Gas:       params.TxGas,
 		To:        &addr,
 		Value:     test.MaxBalance,
 	}

--- a/backend/ethereum/channel/test/tokensetup.go
+++ b/backend/ethereum/channel/test/tokensetup.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 
 	"perun.network/go-perun/backend/ethereum/bindings"
@@ -69,10 +68,9 @@ func NewTokenSetup(ctx context.Context, t *testing.T, rng *rand.Rand, txFinality
 	sb.FundAddress(ctx, acc1.Address)
 	acc2 := &ksWallet.NewRandomAccount(rng).(*keystore.Account).Account
 	sb.FundAddress(ctx, acc2.Address)
-	signer := types.NewEIP155Signer(params.AllEthashProtocolChanges.ChainID)
 	cb := ethchannel.NewContractBackend(
 		sb,
-		keystore.NewTransactor(*ksWallet, signer),
+		keystore.NewTransactor(*ksWallet, SimSigner),
 		txFinalityDepth,
 	)
 

--- a/backend/ethereum/channel/test/transactor.go
+++ b/backend/ethereum/channel/test/transactor.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
@@ -30,10 +29,24 @@ import (
 	"perun.network/go-perun/backend/ethereum/wallet"
 )
 
+// TxType is a transaction type, specifying how it is hashed for signing and how
+// the v value of the signature is coded.
+type TxType int
+
+const (
+	// LegacyTx - legacy transaction with v = {0,1} + 27.
+	LegacyTx TxType = iota
+	// EIP155Tx - EIP155 transaction with v = {0,1} + CHAIN_ID * 2 + 35.
+	EIP155Tx
+	// EIP1559Tx - EIP1559 transaction with v = {0,1}.
+	EIP1559Tx
+)
+
 // TransactorSetup holds the setup for running generic tests on a transactor implementation.
 type TransactorSetup struct {
 	Signer     types.Signer
 	ChainID    int64
+	TxType     TxType // Transaction type to generate and check against this signer
 	Tr         channel.Transactor
 	ValidAcc   accounts.Account // wallet should contain key corresponding to this account.
 	MissingAcc accounts.Account // wallet should not contain key corresponding to this account.
@@ -45,22 +58,37 @@ const signerTestDataMaxLength = 100
 // for the passed signer.
 func GenericSignerTest(t *testing.T, rng *rand.Rand, setup TransactorSetup) {
 	t.Helper()
-	signer := setup.Signer
-	chainID := setup.ChainID
-	data := make([]byte, rng.Int31n(signerTestDataMaxLength)+1)
-	rng.Read(data)
+
+	newTx := func() *types.Transaction {
+		data := make([]byte, rng.Int31n(signerTestDataMaxLength)+1)
+		rng.Read(data)
+		switch setup.TxType {
+		case LegacyTx, EIP155Tx:
+			return types.NewTx(&types.LegacyTx{
+				Value: big.NewInt(rng.Int63()),
+				Data:  data,
+			})
+		case EIP1559Tx:
+			return types.NewTx(&types.DynamicFeeTx{
+				ChainID: big.NewInt(setup.ChainID),
+				Value:   big.NewInt(rng.Int63()),
+				Data:    data,
+			})
+		}
+		panic("unsupported tx type")
+	}
 
 	t.Run("happy", func(t *testing.T) {
 		transactOpts, err := setup.Tr.NewTransactor(setup.ValidAcc)
 		require.NoError(t, err)
-		rawTx := types.NewTransaction(uint64(1), common.Address{}, big.NewInt(1), uint64(1), big.NewInt(1), data)
-		signedTx, err := transactOpts.Signer(setup.ValidAcc.Address, rawTx)
+		tx := newTx()
+		signedTx, err := transactOpts.Signer(setup.ValidAcc.Address, tx)
 		assert.NoError(t, err)
 		require.NotNil(t, signedTx)
 
-		txHash := signer.Hash(rawTx).Bytes()
+		txHash := setup.Signer.Hash(tx).Bytes()
 		v, r, s := signedTx.RawSignatureValues()
-		sig := sigFromRSV(t, r, s, v, chainID)
+		sig := sigFromRSV(t, r, s, v, &setup)
 		pk, err := crypto.SigToPub(txHash, sig)
 		require.NoError(t, err)
 		addr := crypto.PubkeyToAddress(*pk)
@@ -76,30 +104,39 @@ func GenericSignerTest(t *testing.T, rng *rand.Rand, setup TransactorSetup) {
 		transactOpts, err := setup.Tr.NewTransactor(setup.ValidAcc)
 		require.NoError(t, err)
 
-		rawTx := types.NewTransaction(uint64(1), common.Address{}, big.NewInt(1), uint64(1), big.NewInt(1), data)
-		_, err = transactOpts.Signer(setup.MissingAcc.Address, rawTx)
+		_, err = transactOpts.Signer(setup.MissingAcc.Address, newTx())
 		assert.Error(t, err)
 	})
 }
 
-func sigFromRSV(t *testing.T, r, s, _v *big.Int, chainID int64) []byte {
+func sigFromRSV(t *testing.T, r, s, _v *big.Int, setup *TransactorSetup) []byte {
 	t.Helper()
 	const (
-		elemLen      = 32
-		sigLen       = elemLen*2 + 1
-		sigVAdd      = 35
-		sigVSubtract = 27
+		elemLen         = 32
+		sigVEIP155Shift = 35
+		sigVLegacyShift = 27
 	)
-	sig := make([]byte, wallet.SigLen)
-	copy(sig[elemLen-len(r.Bytes()):elemLen], r.Bytes())
-	copy(sig[elemLen*2-len(s.Bytes()):elemLen*2], s.Bytes())
-	v := byte(_v.Uint64()) // Needed for chain ids > 110.
+	var (
+		sig = make([]byte, wallet.SigLen)
+		rb  = r.Bytes()
+		sb  = s.Bytes()
+		v   = byte(_v.Uint64()) // truncation anticipated for large ChainIDs
+	)
+	copy(sig[elemLen-len(rb):elemLen], rb)
+	copy(sig[elemLen*2-len(sb):elemLen*2], sb)
 
-	if chainID == 0 {
-		sig[sigLen-1] = v - sigVSubtract
-	} else {
-		sig[sigLen-1] = v - byte(chainID*2+sigVAdd) // Underflow is ok here.
+	switch setup.TxType {
+	case LegacyTx:
+		v -= sigVLegacyShift
+	case EIP155Tx:
+		v -= byte(setup.ChainID*2 + sigVEIP155Shift) // underflow anticipated
+	case EIP1559Tx:
+		// EIP1559 transactions simply code the y-parity into v, so no correction
+		// necessary.
 	}
-	require.Contains(t, []byte{0, 1}, sig[sigLen-1], "Invalid v")
+	require.Containsf(t, []byte{0, 1}, v,
+		"Invalid v (txType: %v; chainID: %d)", setup.TxType, setup.ChainID)
+
+	sig[wallet.SigLen-1] = v
 	return sig
 }

--- a/backend/ethereum/subscription/eventsub_test.go
+++ b/backend/ethereum/subscription/eventsub_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 
 	"perun.network/go-perun/backend/ethereum/bindings"
@@ -62,7 +61,7 @@ func TestEventSub(t *testing.T) {
 	sb.FundAddress(ctx, account.Address)
 	cb := ethchannel.NewContractBackend(
 		sb,
-		keystore.NewTransactor(*ksWallet, types.NewEIP155Signer(big.NewInt(1337))),
+		keystore.NewTransactor(*ksWallet, test.SimSigner),
 		txFinalityDepth,
 	)
 
@@ -150,7 +149,7 @@ func TestEventSub_Filter(t *testing.T) {
 	sb.FundAddress(ctx, account.Address)
 	cb := ethchannel.NewContractBackend(
 		sb,
-		keystore.NewTransactor(*ksWallet, types.NewEIP155Signer(big.NewInt(1337))),
+		keystore.NewTransactor(*ksWallet, test.SimSigner),
 		txFinalityDepth,
 	)
 

--- a/backend/ethereum/wallet/hd/transactor_test.go
+++ b/backend/ethereum/wallet/hd/transactor_test.go
@@ -47,38 +47,41 @@ func TestTransactor(t *testing.T) {
 		title        string
 		signer       types.Signer
 		chainID      int64
+		txType       test.TxType
 		hideSignHash bool
 	}{
 		{
-			title:   "FrontierSigner",
-			signer:  &types.FrontierSigner{},
-			chainID: 0,
+			title:  "FrontierSigner",
+			signer: &types.FrontierSigner{},
+			txType: test.LegacyTx,
 		},
 		{
-			title:   "HomesteadSigner",
-			signer:  &types.HomesteadSigner{},
-			chainID: 0,
+			title:  "HomesteadSigner",
+			signer: &types.HomesteadSigner{},
+			txType: test.LegacyTx,
 		},
 		{
 			title:        "FrontierSigner (hideSignHash)",
 			signer:       &types.FrontierSigner{},
-			chainID:      0,
+			txType:       test.LegacyTx,
 			hideSignHash: true,
 		},
 		{
 			title:        "HomesteadSigner (hideSignHash)",
 			signer:       &types.HomesteadSigner{},
-			chainID:      0,
+			txType:       test.LegacyTx,
 			hideSignHash: true,
 		},
 		{
 			title:   "EIP155Signer",
 			signer:  types.NewEIP155Signer(big.NewInt(chainID)),
+			txType:  test.EIP155Tx,
 			chainID: chainID,
 		},
 		{
 			title:   "LatestSigner",
 			signer:  types.LatestSignerForChainID(big.NewInt(chainID)),
+			txType:  test.EIP1559Tx,
 			chainID: chainID,
 		},
 	}
@@ -86,14 +89,14 @@ func TestTransactor(t *testing.T) {
 	for _, _t := range tests {
 		_t := _t
 		t.Run(_t.title, func(t *testing.T) {
-			s := newTransactorSetup(t, rng, _t.hideSignHash, _t.signer, _t.chainID)
+			s := newTransactorSetup(t, rng, _t.hideSignHash, _t.signer, _t.chainID, _t.txType)
 			test.GenericSignerTest(t, rng, s)
 		})
 	}
 }
 
 // rand.Rand is preferred over io.Reader here.
-func newTransactorSetup(t *testing.T, prng *rand.Rand, hideSignHash bool, signer types.Signer, chainID int64) test.TransactorSetup {
+func newTransactorSetup(t *testing.T, prng *rand.Rand, hideSignHash bool, signer types.Signer, chainID int64, txType test.TxType) test.TransactorSetup {
 	t.Helper()
 	walletSeed := make([]byte, 20)
 	prng.Read(walletSeed)
@@ -119,6 +122,7 @@ func newTransactorSetup(t *testing.T, prng *rand.Rand, hideSignHash bool, signer
 	return test.TransactorSetup{
 		Signer:     signer,
 		ChainID:    chainID,
+		TxType:     txType,
 		Tr:         hd.NewTransactor(hdWallet.Wallet(), signer),
 		ValidAcc:   accounts.Account{Address: wallet.AsEthAddr(validAcc.Address())},
 		MissingAcc: accounts.Account{Address: common.HexToAddress(missingAddr)},

--- a/backend/ethereum/wallet/hd/transactor_test.go
+++ b/backend/ethereum/wallet/hd/transactor_test.go
@@ -76,6 +76,11 @@ func TestTransactor(t *testing.T) {
 			signer:  types.NewEIP155Signer(big.NewInt(chainID)),
 			chainID: chainID,
 		},
+		{
+			title:   "LatestSigner",
+			signer:  types.LatestSignerForChainID(big.NewInt(chainID)),
+			chainID: chainID,
+		},
 	}
 
 	for _, _t := range tests {

--- a/backend/ethereum/wallet/keystore/transactor_test.go
+++ b/backend/ethereum/wallet/keystore/transactor_test.go
@@ -59,6 +59,11 @@ func TestTxOptsBackend(t *testing.T) {
 			signer:  types.NewEIP155Signer(big.NewInt(chainID)),
 			chainID: chainID,
 		},
+		{
+			title:   "LatestSigner",
+			signer:  types.LatestSignerForChainID(big.NewInt(chainID)),
+			chainID: chainID,
+		},
 	}
 
 	for _, _t := range tests {

--- a/backend/ethereum/wallet/simple/transactor_test.go
+++ b/backend/ethereum/wallet/simple/transactor_test.go
@@ -57,6 +57,11 @@ func TestTxOptsBackend(t *testing.T) {
 			signer:  types.NewEIP155Signer(big.NewInt(chainID)),
 			chainID: chainID,
 		},
+		{
+			title:   "LatestSigner",
+			signer:  types.LatestSignerForChainID(big.NewInt(chainID)),
+			chainID: chainID,
+		},
 	}
 
 	for _, _t := range tests {

--- a/backend/ethereum/wallet/simple/transactor_test.go
+++ b/backend/ethereum/wallet/simple/transactor_test.go
@@ -33,7 +33,7 @@ import (
 // Missing address for which key will not be contained in the wallet.
 const missingAddr = "0x1"
 
-func TestTxOptsBackend(t *testing.T) {
+func TestTransactor(t *testing.T) {
 	rng := pkgtest.Prng(t)
 	chainID := rng.Int63()
 
@@ -41,25 +41,28 @@ func TestTxOptsBackend(t *testing.T) {
 		title   string
 		signer  types.Signer
 		chainID int64
+		txType  test.TxType
 	}{
 		{
-			title:   "FrontierSigner",
-			signer:  &types.FrontierSigner{},
-			chainID: 0,
+			title:  "FrontierSigner",
+			signer: &types.FrontierSigner{},
+			txType: test.LegacyTx,
 		},
 		{
-			title:   "HomesteadSigner",
-			signer:  &types.HomesteadSigner{},
-			chainID: 0,
+			title:  "HomesteadSigner",
+			signer: &types.HomesteadSigner{},
+			txType: test.LegacyTx,
 		},
 		{
 			title:   "EIP155Signer",
 			signer:  types.NewEIP155Signer(big.NewInt(chainID)),
+			txType:  test.EIP155Tx,
 			chainID: chainID,
 		},
 		{
 			title:   "LatestSigner",
 			signer:  types.LatestSignerForChainID(big.NewInt(chainID)),
+			txType:  test.EIP1559Tx,
 			chainID: chainID,
 		},
 	}
@@ -67,13 +70,13 @@ func TestTxOptsBackend(t *testing.T) {
 	for _, _t := range tests {
 		_t := _t
 		t.Run(_t.title, func(t *testing.T) {
-			s := newTransactorSetup(t, rng, _t.signer, _t.chainID)
+			s := newTransactorSetup(t, rng, _t.signer, _t.chainID, _t.txType)
 			test.GenericSignerTest(t, rng, s)
 		})
 	}
 }
 
-func newTransactorSetup(t require.TestingT, prng *rand.Rand, signer types.Signer, chainID int64) test.TransactorSetup {
+func newTransactorSetup(t require.TestingT, prng *rand.Rand, signer types.Signer, chainID int64, txType test.TxType) test.TransactorSetup {
 	simpleWallet := simple.NewWallet()
 	require.NotNil(t, simpleWallet)
 	validAcc := simpleWallet.NewRandomAccount(prng)
@@ -82,6 +85,7 @@ func newTransactorSetup(t require.TestingT, prng *rand.Rand, signer types.Signer
 	return test.TransactorSetup{
 		Signer:     signer,
 		ChainID:    chainID,
+		TxType:     txType,
 		Tr:         simple.NewTransactor(simpleWallet, signer),
 		ValidAcc:   accounts.Account{Address: wallet.AsEthAddr(validAcc.Address())},
 		MissingAcc: accounts.Account{Address: common.HexToAddress(missingAddr)},


### PR DESCRIPTION
- eth/channel: Use types.LatestSigner for all sim backend tests
  - Before, `types.EIP155Signer`s were created in many different places.
It is recommended by the geth folks to use `types.LatestSigner` instead.
This was streamlined an there's now a common `channel/test.SimSigner` that
can always be used together with the simulated backend.
  - `FundAddress` and `Test_ConfirmTransaction` were adapted to use the
new `types.DynamicFeeTx`.
  - The unused `test.GasLimit` variable was deleted.
  - The `test.GasPrice` variable was renamed to `InitialGasBaseFee` and its
description updated.
- eth/channel: Don't set `GasPrice` in `ContractBackend.NewTransactor`
  - Setting `TransactOpts.GasPrice` forces the transactions to be sent as a
legacy transaction, instead of a type 2 EIP1559, which results in much
higher gas costs.
  - Also remove the `SuggestedGasPrice` method from the `SimulatedBackend`, as
it is not used anymore, because EIP1559 TXs are now sent everywhere.

Opened as a draft to let @ndzik try it out first if we truly now send EIP1559 txs.
Original issue in Erdstall is at https://github.com/perun-network/erdstall-ext/issues/121