### PR TITLE
Initialize wire encoding explicitly

### DIFF
--- a/client/proposalmsgs_test.go
+++ b/client/proposalmsgs_test.go
@@ -24,7 +24,6 @@ import (
 	"perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
 	clienttest "perun.network/go-perun/client/test"
-	_ "perun.network/go-perun/wire/perunio/serializer" // wire serialzer init
 	peruniotest "perun.network/go-perun/wire/perunio/test"
 	pkgtest "polycry.pt/poly-go/test"
 )

--- a/wire/controlmsgs_test.go
+++ b/wire/controlmsgs_test.go
@@ -17,7 +17,6 @@ package wire_test
 import (
 	"testing"
 
-	_ "perun.network/go-perun/wire/perunio/serializer" // wire serialzer init
 	peruniotest "perun.network/go-perun/wire/perunio/test"
 	wiretest "perun.network/go-perun/wire/test"
 )

--- a/wire/encode.go
+++ b/wire/encode.go
@@ -24,17 +24,6 @@ import (
 	"perun.network/go-perun/wire/perunio"
 )
 
-var envelopeSerializer EnvelopeSerializer
-
-// SetEnvelopeSerializer sets the global envelope serializer instance. Must not
-// be called directly but through importing the needed backend.
-func SetEnvelopeSerializer(e EnvelopeSerializer) {
-	if envelopeSerializer != nil {
-		panic("envelope serializer already set")
-	}
-	envelopeSerializer = e
-}
-
 type (
 	// Msg is the top-level abstraction for all messages sent between Perun
 	// nodes.
@@ -58,18 +47,6 @@ type (
 		Decode(r io.Reader) (*Envelope, error)
 	}
 )
-
-// EncodeEnvelope serializes the envelope into the writer, using the global
-// envelope serialzer instance.
-func EncodeEnvelope(w io.Writer, env *Envelope) error {
-	return envelopeSerializer.Encode(w, env)
-}
-
-// DecodeEnvelope deserializes an envelope from the reader, using the global
-// envelope serialzer instance.
-func DecodeEnvelope(r io.Reader) (*Envelope, error) {
-	return envelopeSerializer.Decode(r)
-}
 
 // EncodeMsg encodes a message into an io.Writer. It also encodes the message
 // type whereas the Msg.Encode implementation is assumed not to write the type.

--- a/wire/net/bus.go
+++ b/wire/net/bus.go
@@ -45,14 +45,14 @@ const (
 
 // NewBus creates a new network bus. The dialer and listener are used to
 // establish new connections internally, while id is this node's identity.
-func NewBus(id wire.Account, d Dialer) *Bus {
+func NewBus(id wire.Account, d Dialer, s wire.EnvelopeSerializer) *Bus {
 	b := &Bus{
 		mainRecv: wire.NewReceiver(),
 		recvs:    make(map[wallet.AddrKey]wire.Consumer),
 	}
 
 	onNewEndpoint := func(wire.Address) wire.Consumer { return b.mainRecv }
-	b.reg = NewEndpointRegistry(id, onNewEndpoint, d)
+	b.reg = NewEndpointRegistry(id, onNewEndpoint, d, s)
 	go b.dispatchMsgs()
 
 	return b

--- a/wire/net/bus_test.go
+++ b/wire/net/bus_test.go
@@ -22,6 +22,7 @@ import (
 	"perun.network/go-perun/wire"
 	"perun.network/go-perun/wire/net"
 	nettest "perun.network/go-perun/wire/net/test"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 	wiretest "perun.network/go-perun/wire/test"
 )
 
@@ -32,7 +33,7 @@ func TestBus(t *testing.T) {
 	var hub nettest.ConnHub
 
 	wiretest.GenericBusTest(t, func(acc wire.Account) wire.Bus {
-		bus := net.NewBus(acc, hub.NewNetDialer())
+		bus := net.NewBus(acc, hub.NewNetDialer(), perunio.Serializer())
 		hub.OnClose(func() { bus.Close() })
 		go bus.Listen(hub.NewNetListener(acc.Address()))
 		return bus

--- a/wire/net/dialer.go
+++ b/wire/net/dialer.go
@@ -23,13 +23,15 @@ import (
 // Dialer is an interface that allows creating a connection to a peer via its
 // Perun address. The established connections are not authenticated yet.
 type Dialer interface {
-	// Dial creates a connection to a peer.
-	// The passed context is used to abort the dialing process. The returned
-	// connection might not belong to the requested address.
+	// Dial creates a connection to a peer. The passed context is used to abort
+	// the dialing process. The returned connection might not belong to the
+	// requested address.
+	//
+	// `ser` is used for message serialization.
 	//
 	// Dial needs to be reentrant, and concurrent calls to Close() must abort
 	// any ongoing Dial() calls.
-	Dial(ctx context.Context, addr wire.Address) (Conn, error)
+	Dial(ctx context.Context, addr wire.Address, ser wire.EnvelopeSerializer) (Conn, error)
 	// Close aborts any ongoing calls to Dial().
 	//
 	// Close() needs to be reentrant, and repeated calls to Close() need to

--- a/wire/net/endpoint_internal_test.go
+++ b/wire/net/endpoint_internal_test.go
@@ -27,6 +27,7 @@ import (
 	_ "perun.network/go-perun/backend/sim" // backend init
 	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 	wiretest "perun.network/go-perun/wire/test"
 	"polycry.pt/poly-go/test"
 )
@@ -53,7 +54,7 @@ func makeSetup(rng *rand.Rand) *setup {
 }
 
 // Dial simulates creating a connection to a.
-func (s *setup) Dial(ctx context.Context, addr wire.Address) (Conn, error) {
+func (s *setup) Dial(ctx context.Context, addr wire.Address, _ wire.EnvelopeSerializer) (Conn, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -99,7 +100,7 @@ func makeClient(conn Conn, rng *rand.Rand, dialer Dialer) *client {
 	receiver := wire.NewReceiver()
 	registry := NewEndpointRegistry(wallettest.NewRandomAccount(rng), func(wire.Address) wire.Consumer {
 		return receiver
-	}, dialer)
+	}, dialer, perunio.Serializer())
 
 	return &client{
 		endpoint: registry.addEndpoint(wallettest.NewRandomAddress(rng), conn, true),

--- a/wire/net/endpoint_registry_external_test.go
+++ b/wire/net/endpoint_registry_external_test.go
@@ -26,6 +26,7 @@ import (
 	"perun.network/go-perun/wire"
 	"perun.network/go-perun/wire/net"
 	nettest "perun.network/go-perun/wire/net/test"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 	ctxtest "polycry.pt/poly-go/context/test"
 	"polycry.pt/poly-go/sync"
 	"polycry.pt/poly-go/test"
@@ -43,8 +44,8 @@ func TestEndpointRegistry_Get_Pair(t *testing.T) {
 	var hub nettest.ConnHub
 	dialerID := wallettest.NewRandomAccount(rng)
 	listenerID := wallettest.NewRandomAccount(rng)
-	dialerReg := net.NewEndpointRegistry(dialerID, nilConsumer, hub.NewNetDialer())
-	listenerReg := net.NewEndpointRegistry(listenerID, nilConsumer, nil)
+	dialerReg := net.NewEndpointRegistry(dialerID, nilConsumer, hub.NewNetDialer(), perunio.Serializer())
+	listenerReg := net.NewEndpointRegistry(listenerID, nilConsumer, nil, perunio.Serializer())
 	listener := hub.NewNetListener(listenerID.Address())
 
 	done := make(chan struct{})
@@ -88,8 +89,8 @@ func TestEndpointRegistry_Get_Multiple(t *testing.T) {
 		t.Logf("subscribing %s\n", addr)
 		return nil
 	}
-	dialerReg := net.NewEndpointRegistry(dialerID, logPeer, dialer)
-	listenerReg := net.NewEndpointRegistry(listenerID, logPeer, nil)
+	dialerReg := net.NewEndpointRegistry(dialerID, logPeer, dialer, perunio.Serializer())
+	listenerReg := net.NewEndpointRegistry(listenerID, logPeer, nil, perunio.Serializer())
 	listener := hub.NewNetListener(listenerID.Address())
 
 	done := make(chan struct{})

--- a/wire/net/exchange_addr_internal_test.go
+++ b/wire/net/exchange_addr_internal_test.go
@@ -23,7 +23,6 @@ import (
 
 	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
-	_ "perun.network/go-perun/wire/protobuf" // wire serialzer init
 	wiretest "perun.network/go-perun/wire/test"
 	ctxtest "polycry.pt/poly-go/context/test"
 	"polycry.pt/poly-go/test"

--- a/wire/net/listener.go
+++ b/wire/net/listener.go
@@ -14,17 +14,21 @@
 
 package net
 
+import "perun.network/go-perun/wire"
+
 // Listener is an interface that allows listening for peer incoming connections.
 // The accepted connections still need to be authenticated.
 type Listener interface {
 	// Accept accepts an incoming connection, which still has to perform
 	// authentication to exchange addresses.
 	//
+	// `ser` specifies the message serialization format.
+	//
 	// This function does not have to be reentrant, but concurrent calls to
 	// Close() must abort ongoing Accept() calls. Accept() must only return
 	// errors after Close() was called or an unrecoverable fatal error occurred
 	// in the Listener and it is closed.
-	Accept() (Conn, error)
+	Accept(ser wire.EnvelopeSerializer) (Conn, error)
 	// Close closes the listener and aborts any ongoing Accept() call.
 	Close() error
 }

--- a/wire/net/simple/dialer.go
+++ b/wire/net/simple/dialer.go
@@ -44,6 +44,7 @@ var _ wirenet.Dialer = (*Dialer)(nil)
 // attempts. Leaving the timeout as 0 will result in no timeouts. Standard OS
 // timeouts may still apply even when no timeout is selected. The network string
 // controls the type of connection that the dialer can dial.
+// `serializer` defines the message encoding.
 func NewNetDialer(network string, defaultTimeout time.Duration) *Dialer {
 	return &Dialer{
 		peers:   make(map[wallet.AddrKey]string),
@@ -71,7 +72,7 @@ func (d *Dialer) host(key wallet.AddrKey) (string, bool) {
 }
 
 // Dial implements Dialer.Dial().
-func (d *Dialer) Dial(ctx context.Context, addr wire.Address) (wirenet.Conn, error) {
+func (d *Dialer) Dial(ctx context.Context, addr wire.Address, ser wire.EnvelopeSerializer) (wirenet.Conn, error) {
 	done := make(chan struct{})
 	defer close(done)
 
@@ -97,7 +98,7 @@ func (d *Dialer) Dial(ctx context.Context, addr wire.Address) (wirenet.Conn, err
 		return nil, errors.Wrap(err, "failed to dial peer")
 	}
 
-	return wirenet.NewIoConn(conn), nil
+	return wirenet.NewIoConn(conn, ser), nil
 }
 
 // Register registers a network address for a peer address.

--- a/wire/net/simple/listener.go
+++ b/wire/net/simple/listener.go
@@ -18,6 +18,7 @@ import (
 	"net"
 
 	"github.com/pkg/errors"
+	"perun.network/go-perun/wire"
 	wirenet "perun.network/go-perun/wire/net"
 )
 
@@ -50,11 +51,11 @@ func NewUnixListener(address string) (*Listener, error) {
 }
 
 // Accept implements peer.Dialer.Accept().
-func (l *Listener) Accept() (wirenet.Conn, error) {
+func (l *Listener) Accept(ser wire.EnvelopeSerializer) (wirenet.Conn, error) {
 	conn, err := l.Listener.Accept()
 	if err != nil {
 		return nil, errors.Wrap(err, "accept failed")
 	}
 
-	return wirenet.NewIoConn(conn), nil
+	return wirenet.NewIoConn(conn, ser), nil
 }

--- a/wire/net/simple/listener_internal_test.go
+++ b/wire/net/simple/listener_internal_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 
 	"polycry.pt/poly-go/context/test"
 )
@@ -73,6 +74,7 @@ func TestNewListener(t *testing.T) {
 func TestListener_Accept(t *testing.T) {
 	// Happy case already tested in TestDialer_Dial.
 
+	ser := perunio.Serializer()
 	timeout := 100 * time.Millisecond
 	t.Run("timeout", func(t *testing.T) {
 		l, err := NewTCPListener(addr)
@@ -80,7 +82,7 @@ func TestListener_Accept(t *testing.T) {
 		defer l.Close()
 
 		test.AssertNotTerminates(t, timeout, func() {
-			l.Accept() //nolint:errcheck
+			l.Accept(ser) //nolint:errcheck
 		})
 	})
 
@@ -90,7 +92,7 @@ func TestListener_Accept(t *testing.T) {
 		l.Close()
 
 		test.AssertTerminates(t, timeout, func() {
-			conn, err := l.Accept()
+			conn, err := l.Accept(ser)
 			assert.Nil(t, conn)
 			assert.Error(t, err)
 		})

--- a/wire/net/test/connhub.go
+++ b/wire/net/test/connhub.go
@@ -65,7 +65,7 @@ func (h *ConnHub) NewNetDialer() *Dialer {
 		panic("ConnHub already closed")
 	}
 
-	dialer := &Dialer{hub: h}
+	dialer := NewDialer(h)
 	h.dialers.insert(dialer)
 	dialer.OnClose(func() {
 		h.dialers.erase(dialer) //nolint:errcheck

--- a/wire/net/test/dialer_internal_test.go
+++ b/wire/net/test/dialer_internal_test.go
@@ -21,17 +21,19 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"perun.network/go-perun/wallet/test"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 	pkgtest "polycry.pt/poly-go/test"
 )
 
 func TestDialer_Dial(t *testing.T) {
 	rng := pkgtest.Prng(t)
+	ser := perunio.Serializer()
 	// Closed dialer must always fail.
 	t.Run("closed", func(t *testing.T) {
 		var d Dialer
 		d.Close()
 
-		conn, err := d.Dial(context.Background(), test.NewRandomAddress(rng))
+		conn, err := d.Dial(context.Background(), test.NewRandomAddress(rng), ser)
 		assert.Nil(t, conn)
 		assert.Error(t, err)
 	})
@@ -41,7 +43,7 @@ func TestDialer_Dial(t *testing.T) {
 		var d Dialer
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		conn, err := d.Dial(ctx, test.NewRandomAddress(rng))
+		conn, err := d.Dial(ctx, test.NewRandomAddress(rng), ser)
 		assert.Nil(t, conn)
 		assert.Error(t, err)
 	})

--- a/wire/net/test/listener.go
+++ b/wire/net/test/listener.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"perun.network/go-perun/wire"
 	wirenet "perun.network/go-perun/wire/net"
 	"polycry.pt/poly-go/sync"
 )
@@ -47,7 +48,7 @@ func NewNetListener() *Listener {
 
 // Accept returns the next connection that is enqueued via Put(). This function
 // blocks until either Put() is called or until the listener is closed.
-func (l *Listener) Accept() (wirenet.Conn, error) {
+func (l *Listener) Accept(wire.EnvelopeSerializer) (wirenet.Conn, error) {
 	if l.IsClosed() {
 		return nil, errors.New("listener closed")
 	}

--- a/wire/net/test/pipeconn.go
+++ b/wire/net/test/pipeconn.go
@@ -21,6 +21,7 @@ import (
 
 	"perun.network/go-perun/wire"
 	wirenet "perun.network/go-perun/wire/net"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 	"polycry.pt/poly-go/sync/atomic"
 )
 
@@ -63,5 +64,6 @@ func (c *Conn) IsClosed() bool {
 func NewTestConnPair() (a wirenet.Conn, b wirenet.Conn) {
 	closed := new(atomic.Bool)
 	c0, c1 := net.Pipe()
-	return &Conn{closed, wirenet.NewIoConn(c0)}, &Conn{closed, wirenet.NewIoConn(c1)}
+	ser := perunio.Serializer()
+	return &Conn{closed, wirenet.NewIoConn(c0, ser)}, &Conn{closed, wirenet.NewIoConn(c1, ser)}
 }

--- a/wire/perunio/serializer/serializer.go
+++ b/wire/perunio/serializer/serializer.go
@@ -22,11 +22,12 @@ import (
 	"perun.network/go-perun/wire/perunio"
 )
 
-type serializer struct{}
-
-func init() {
-	wire.SetEnvelopeSerializer(serializer{})
+// Serializer returns a perunio serializer.
+func Serializer() wire.EnvelopeSerializer {
+	return serializer{}
 }
+
+type serializer struct{}
 
 // Encode encodes the envelope into the wire using perunio encoding format.
 func (serializer) Encode(w io.Writer, env *wire.Envelope) error {

--- a/wire/perunio/test/msgtest.go
+++ b/wire/perunio/test/msgtest.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"perun.network/go-perun/wire"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 	wiretest "perun.network/go-perun/wire/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
@@ -30,17 +31,21 @@ type serializableEnvelope struct {
 	env *wire.Envelope
 }
 
+var serializer = perunio.Serializer()
+
 func (e *serializableEnvelope) Encode(writer io.Writer) error {
-	return wire.EncodeEnvelope(writer, e.env)
+	return serializer.Encode(writer, e.env)
 }
 
 func (e *serializableEnvelope) Decode(reader io.Reader) (err error) {
-	e.env, err = wire.DecodeEnvelope(reader)
+	e.env, err = serializer.Decode(reader)
 	return err
 }
 
 func newSerializableEnvelope(rng *rand.Rand, msg wire.Msg) *serializableEnvelope {
-	return &serializableEnvelope{env: wiretest.NewRandomEnvelope(rng, msg)}
+	return &serializableEnvelope{
+		env: wiretest.NewRandomEnvelope(rng, msg),
+	}
 }
 
 // MsgSerializerTest performs generic serializer tests on a wire.Msg object.
@@ -48,6 +53,6 @@ func newSerializableEnvelope(rng *rand.Rand, msg wire.Msg) *serializableEnvelope
 // and the registration of the corresponding decoders.
 func MsgSerializerTest(t *testing.T, msg wire.Msg) {
 	t.Helper()
-
-	GenericSerializerTest(t, newSerializableEnvelope(pkgtest.Prng(t), msg))
+	e := newSerializableEnvelope(pkgtest.Prng(t), msg)
+	GenericSerializerTest(t, e)
 }

--- a/wire/protobuf/serializer.go
+++ b/wire/protobuf/serializer.go
@@ -27,8 +27,9 @@ import (
 
 type serializer struct{}
 
-func init() {
-	wire.SetEnvelopeSerializer(serializer{})
+// Serializer returns a protobuf serializer.
+func Serializer() wire.EnvelopeSerializer {
+	return serializer{}
 }
 
 // Encode encodes an envelope from the reader using protocol buffers

--- a/wire/protobuf/serializer_test.go
+++ b/wire/protobuf/serializer_test.go
@@ -20,7 +20,6 @@ import (
 	_ "perun.network/go-perun/backend/sim/channel"
 	_ "perun.network/go-perun/backend/sim/wallet"
 	clienttest "perun.network/go-perun/client/test"
-	_ "perun.network/go-perun/wire/protobuf"
 	protobuftest "perun.network/go-perun/wire/protobuf/test"
 	wiretest "perun.network/go-perun/wire/test"
 )

--- a/wire/protobuf/test/serializertest.go
+++ b/wire/protobuf/test/serializertest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/protobuf"
 	pkgtest "polycry.pt/poly-go/test"
 )
 
@@ -36,9 +37,10 @@ func MsgSerializerTest(t *testing.T, msg wire.Msg) {
 	envelope.Msg = msg
 
 	var buff bytes.Buffer
-	require.NoError(t, wire.EncodeEnvelope(&buff, envelope))
+	ser := protobuf.Serializer()
+	require.NoError(t, ser.Encode(&buff, envelope))
 
-	gotEnvelope, err := wire.DecodeEnvelope(&buff)
+	gotEnvelope, err := ser.Decode(&buff)
 	require.NoError(t, err)
 	assert.EqualValues(t, envelope, gotEnvelope)
 }

--- a/wire/test/serializinglocalbus.go
+++ b/wire/test/serializinglocalbus.go
@@ -19,17 +19,20 @@ import (
 	"context"
 
 	"perun.network/go-perun/wire"
+	perunio "perun.network/go-perun/wire/perunio/serializer"
 )
 
 // SerializingLocalBus is a local bus that also serializes messages for testing.
 type SerializingLocalBus struct {
 	*wire.LocalBus
+	ser wire.EnvelopeSerializer
 }
 
 // NewSerializingLocalBus creates a new serializing local bus.
 func NewSerializingLocalBus() *SerializingLocalBus {
 	return &SerializingLocalBus{
 		LocalBus: wire.NewLocalBus(),
+		ser:      perunio.Serializer(),
 	}
 }
 
@@ -38,12 +41,12 @@ func (b *SerializingLocalBus) Publish(ctx context.Context, e *wire.Envelope) (er
 	// Serialize and deserialize the envelope before publishing it on the local
 	// bus, to simulate envelope serialization.
 	var buf bytes.Buffer
-	err = wire.EncodeEnvelope(&buf, e)
+	err = b.ser.Encode(&buf, e)
 	if err != nil {
 		return
 	}
 
-	deserializedEnvelope, err := wire.DecodeEnvelope(&buf)
+	deserializedEnvelope, err := b.ser.Decode(&buf)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR proposes to initialize the wire encoding explicitly when needed, instead of setting it via an implicit import. This allows a user to have a better understanding which component uses which encoding and when setting an encoding is not necessary (for example, in case of using a local bus).