### PR TITLE
JSON Marshaling of channel.State and Params

### DIFF
--- a/backend/sim/wallet/address.go
+++ b/backend/sim/wallet/address.go
@@ -16,6 +16,7 @@ package wallet
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
@@ -124,5 +125,24 @@ func (a *Address) UnmarshalBinary(data []byte) error {
 	a.Y = new(big.Int).SetBytes(data[elemLen:])
 	a.Curve = curve
 
+	return nil
+}
+
+type jsonAddress struct {
+	X *big.Int `json:"x"`
+	Y *big.Int `json:"y"`
+}
+
+// MarshalJSON returns the JSON encoding of the Address.
+func (a *Address) MarshalJSON() ([]byte, error) {
+	return json.Marshal(jsonAddress{X: a.X, Y: a.Y})
+}
+
+// UnmarshalJSON decodes the given json data into the Address.
+func (a *Address) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, (*ecdsa.PublicKey)(a)); err != nil {
+		return fmt.Errorf("unmarshaling into jsonAddress: %w", err)
+	}
+	a.Curve = curve
 	return nil
 }

--- a/backend/sim/wallet/address_test.go
+++ b/backend/sim/wallet/address_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wallet_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"polycry.pt/poly-go/test"
+
+	"perun.network/go-perun/backend/sim/wallet"
+)
+
+func TestAddressJSONMarshaling(t *testing.T) {
+	rng := test.Prng(t)
+	addr := wallet.NewRandomAddress(rng)
+
+	b, err := json.Marshal(addr)
+	require.NoError(t, err)
+
+	addr1 := new(wallet.Address)
+	require.NoError(t, json.Unmarshal(b, addr1))
+	require.Equal(t, addr, addr1)
+}

--- a/channel/allocation.go
+++ b/channel/allocation.go
@@ -68,12 +68,12 @@ type (
 	// Locked holds the locked allocations to sub-app-channels.
 	Allocation struct {
 		// Assets are the asset types held in this channel
-		Assets []Asset
+		Assets []Asset `json:"assets"`
 		// Balances is the allocation of assets to the Params.Parts
-		Balances
+		Balances `json:"balances"`
 		// Locked describes the funds locked in subchannels. There is one entry
 		// per subchannel.
-		Locked []SubAlloc
+		Locked []SubAlloc `json:"locked"`
 	}
 
 	// Balances two dimensional slice of `Bal`. Is a `Summer`.
@@ -83,9 +83,10 @@ type (
 	// The size of the balances slice must be of the same size as the assets slice
 	// of the channel Params.
 	SubAlloc struct {
-		ID       ID
-		Bals     []Bal
-		IndexMap []Index // Maps participant indices of the sub-channel to participant indices of the parent channel.
+		ID   ID    `json:"id"`
+		Bals []Bal `json:"balances"`
+		// Maps participant indices of the sub-channel to participant indices of the parent channel.
+		IndexMap []Index `json:"indexes"`
 	}
 
 	// Bal is a single asset's balance.

--- a/channel/jsonunmarshalers.go
+++ b/channel/jsonunmarshalers.go
@@ -1,0 +1,99 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"perun.network/go-perun/wallet"
+)
+
+type (
+	jsonParams struct {
+		ChallengeDuration uint64
+		Parts             []json.RawMessage
+		Nonce             Nonce
+		LedgerChannel     bool
+		VirtualChannel    bool
+	}
+
+	jsonState struct {
+		ID         *ID            `json:"id"`
+		Version    *uint64        `json:"version"`
+		Allocation jsonAllocation `json:"allocation"`
+		IsFinal    *bool          `json:"final"`
+	}
+
+	jsonAllocation struct {
+		Assets   []json.RawMessage `json:"assets"`
+		Balances *Balances         `json:"balances"`
+		Locked   *[]SubAlloc       `json:"locked"`
+	}
+)
+
+// UnmarshalJSON decodes the given json data into the Params.
+func (p *Params) UnmarshalJSON(data []byte) error {
+	var jp jsonParams
+	if err := json.Unmarshal(data, &jp); err != nil {
+		return fmt.Errorf("unmarshaling into jsonParams: %w", err)
+	}
+
+	parts := make([]wallet.Address, 0, len(jp.Parts))
+	for i, rawPart := range jp.Parts {
+		a := wallet.NewAddress()
+		if err := json.Unmarshal(rawPart, &a); err != nil {
+			return fmt.Errorf("unmarshaling participant[%d]: %w", i, err)
+		}
+		parts = append(parts, a)
+	}
+
+	params, err := NewParams(
+		jp.ChallengeDuration, parts, NoApp(), jp.Nonce,
+		jp.LedgerChannel, jp.VirtualChannel)
+	if err != nil {
+		return err
+	}
+	*p = *params
+	return nil
+}
+
+// UnmarshalJSON decodes the given json data into the State.
+func (s *State) UnmarshalJSON(data []byte) error {
+	js := jsonState{
+		ID:      &s.ID,
+		Version: &s.Version,
+		IsFinal: &s.IsFinal,
+		Allocation: jsonAllocation{
+			Balances: &s.Balances,
+			Locked:   &s.Locked,
+		},
+	}
+	if err := json.Unmarshal(data, &js); err != nil {
+		return fmt.Errorf("unmarshaling into jsonState: %w", err)
+	}
+
+	s.App = NoApp()
+	s.Data = NoData()
+	s.Assets = make([]Asset, 0, len(js.Allocation.Assets))
+	for i, rawAsset := range js.Allocation.Assets {
+		a := NewAsset()
+		if err := json.Unmarshal(rawAsset, &a); err != nil {
+			return fmt.Errorf("unmarshaling asset[%d]: %w", i, err)
+		}
+		s.Assets = append(s.Assets, a)
+	}
+	return s.Allocation.Valid()
+}

--- a/channel/jsonunmarshalers_test.go
+++ b/channel/jsonunmarshalers_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package channel_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"perun.network/go-perun/channel"
+	chtest "perun.network/go-perun/channel/test"
+
+	"polycry.pt/poly-go/test"
+)
+
+func TestStateJSONMarshaling(t *testing.T) {
+	rng := test.Prng(t)
+	state := chtest.NewRandomState(rng, chtest.WithoutApp())
+
+	b, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	state1 := new(channel.State)
+	require.NoError(t, json.Unmarshal(b, state1))
+	require.Equal(t, state, state1)
+}
+
+func TestParamsJSONMarshaling(t *testing.T) {
+	rng := test.Prng(t)
+	params := chtest.NewRandomParams(rng, chtest.WithoutApp())
+
+	b, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	params1 := new(channel.Params)
+	require.NoError(t, json.Unmarshal(b, params1))
+	require.Equal(t, params, params1)
+}

--- a/channel/params.go
+++ b/channel/params.go
@@ -61,18 +61,18 @@ type Params struct {
 	// ChannelID is the channel ID as calculated by the backend
 	id ID
 	// ChallengeDuration in seconds during disputes
-	ChallengeDuration uint64
+	ChallengeDuration uint64 `json:"challengeDuration"`
 	// Parts are the channel participants
-	Parts []wallet.Address
+	Parts []wallet.Address `json:"parts"`
 	// App identifies the application that this channel is running. It is
 	// optional, and if nil, signifies that a channel is a payment channel.
-	App App `cloneable:"shallow"`
+	App App `cloneable:"shallow" json:"-"`
 	// Nonce is a random value that makes the channel's ID unique.
-	Nonce Nonce
+	Nonce Nonce `json:"nonce"`
 	// LedgerChannel specifies whether this is a ledger channel.
-	LedgerChannel bool
+	LedgerChannel bool `json:"ledgerChannel"`
 	// VirtualChannel specifies whether this is a virtual channel.
-	VirtualChannel bool
+	VirtualChannel bool `json:"virtualChannel"`
 }
 
 // ID returns the channelID of this channel.


### PR DESCRIPTION
- sim/wallet: Add Address JSON Marshaling
- channel: Add Params, State, Allocation JSON Marshaling

For now, only `States` and `Params` without `App` and `Data` are supported.

While using any particular backend, the implementations of `Asset` and `Address` must be JSON marshalable.