### PR TITLE
wallet.CloneAddress(es)

### DIFF
--- a/channel/params.go
+++ b/channel/params.go
@@ -146,24 +146,10 @@ func NewParamsUnsafe(challengeDuration uint64, parts []wallet.Address, app App, 
 
 // Clone returns a deep copy of Params.
 func (p *Params) Clone() *Params {
-	clonedParts := make([]wallet.Address, len(p.Parts))
-	for i, part := range p.Parts {
-		marshalledAddr, err := part.MarshalBinary()
-		if err != nil {
-			log.WithError(err).Panic("Could not encode part")
-		}
-
-		addr := wallet.NewAddress()
-		if err := addr.UnmarshalBinary(marshalledAddr); err != nil {
-			log.WithError(err).Panic("Could not clone params' addresses")
-		}
-		clonedParts[i] = addr
-	}
-
 	return &Params{
 		id:                p.ID(),
 		ChallengeDuration: p.ChallengeDuration,
-		Parts:             clonedParts,
+		Parts:             wallet.CloneAddresses(p.Parts),
 		App:               p.App,
 		Nonce:             new(big.Int).Set(p.Nonce),
 		LedgerChannel:     p.LedgerChannel,

--- a/wallet/address.go
+++ b/wallet/address.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"perun.network/go-perun/log"
 	"perun.network/go-perun/wire/perunio"
 )
 
@@ -56,6 +57,32 @@ func IndexOfAddr(addrs []Address, addr Address) int {
 	}
 
 	return -1
+}
+
+// CloneAddress returns a clone of an Address using its binary marshaling
+// implementation. It panics if an error occurs during binary (un)marshaling.
+func CloneAddress(a Address) Address {
+	data, err := a.MarshalBinary()
+	if err != nil {
+		log.WithError(err).Panic("error binary-marshaling Address")
+	}
+
+	clone := NewAddress()
+	if err := clone.UnmarshalBinary(data); err != nil {
+		log.WithError(err).Panic("error binary-unmarshaling Address")
+	}
+	return clone
+}
+
+// CloneAddresses returns a clone of a slice of Addresses using their binary
+// marshaling implementation. It panics if an error occurs during binary
+// (un)marshaling.
+func CloneAddresses(as []Address) []Address {
+	clones := make([]Address, 0, len(as))
+	for _, a := range as {
+		clones = append(clones, CloneAddress(a))
+	}
+	return clones
 }
 
 // AddressPredicate is a function for filtering Addresses.

--- a/wallet/address_test.go
+++ b/wallet/address_test.go
@@ -88,3 +88,22 @@ func TestAddrKey(t *testing.T) {
 		require.True(t, a.Equal(wallet.FromKey(wallet.Key(a))))
 	}
 }
+
+func TestCloneAddress(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	addr := wallettest.NewRandomAddress(rng)
+	addr0 := wallet.CloneAddress(addr)
+	require.Equal(t, addr, addr0)
+	require.NotSame(t, addr, addr0)
+}
+
+func TestCloneAddresses(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	addrs := wallettest.NewRandomAddresses(rng, 3)
+	addrs0 := wallet.CloneAddresses(addrs)
+	require.Equal(t, addrs, addrs0)
+	require.NotSame(t, addrs, addrs0)
+	for i, a := range addrs {
+		require.NotSame(t, a, addrs0[i])
+	}
+}


### PR DESCRIPTION
- wallet: Add CloneAddress(es)
- channel: Use CloneAddresses in Params.Clone

It is convenient for users of the go-perun lib to have means for `wallet.Address` cloning. It was already done in `Params.Clone` so I extracted the functionality into the `wallet` package. No interfaces etc changed.