### PR TITLE
App channel test

### DIFF
--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -100,7 +100,7 @@ func (c *Channel) handleEvents(eventsSub watcher.AdjudicatorSub, h AdjudicatorEv
 			if !ok {
 				return nil
 			}
-			log.Infof("event %v", e)
+			log.WithField("channel", c.Params().ID()).WithField("participant", c.Idx()).Infof("event %T: %v", e, e)
 			if err := c.setMachinePhase(c.Ctx(), e); err != nil {
 				return errors.WithMessage(err, "setting machine phase")
 			}

--- a/client/appchannel_test.go
+++ b/client/appchannel_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"perun.network/go-perun/channel"
+	chtest "perun.network/go-perun/channel/test"
+	"perun.network/go-perun/client"
+	clienttest "perun.network/go-perun/client/test"
+	"perun.network/go-perun/wallet/test"
+	"perun.network/go-perun/wire"
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+func TestProgression(t *testing.T) {
+	rng := pkgtest.Prng(t)
+
+	setups := NewSetups(rng, []string{"Paul", "Paula"})
+	roles := [2]clienttest.Executer{
+		clienttest.NewPaul(t, setups[0]),
+		clienttest.NewPaula(t, setups[1]),
+	}
+
+	appAddress := test.NewRandomAddress(rng)
+	app := channel.NewMockApp(appAddress)
+	channel.RegisterApp(app)
+
+	execConfig := &clienttest.ProgressionExecConfig{
+		BaseExecConfig: clienttest.MakeBaseExecConfig(
+			[2]wire.Address{setups[0].Identity.Address(), setups[1].Identity.Address()},
+			chtest.NewRandomAsset(rng),
+			[2]*big.Int{big.NewInt(99), big.NewInt(1)},
+			client.WithApp(app, channel.NewMockOp(channel.OpValid)),
+		),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
+	defer cancel()
+	err := clienttest.ExecuteTwoPartyTest(ctx, roles, execConfig)
+	assert.NoError(t, err)
+}

--- a/client/client_persistence_test.go
+++ b/client/client_persistence_test.go
@@ -27,7 +27,7 @@ func TestPersistencePetraRobert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 
-	runTwoPartyTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
+	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
 		setups = NewSetupsPersistence(t, rng, []string{"Petra", "Robert"})
 		roles = [2]ctest.Executer{
 			ctest.NewPetra(t, setups[0]),

--- a/client/client_role_test.go
+++ b/client/client_role_test.go
@@ -90,7 +90,7 @@ func NewClients(t *testing.T, rng *rand.Rand, names []string) []*Client {
 	return clients
 }
 
-func runTwoPartyTest(ctx context.Context, t *testing.T, setup func(*rand.Rand) ([]ctest.RoleSetup, [2]ctest.Executer)) {
+func runAliceBobTest(ctx context.Context, t *testing.T, setup func(*rand.Rand) ([]ctest.RoleSetup, [2]ctest.Executer)) {
 	t.Helper()
 	rng := test.Prng(t)
 	for i := 0; i < 2; i++ {

--- a/client/happy_test.go
+++ b/client/happy_test.go
@@ -26,7 +26,7 @@ func TestHappyAliceBob(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 
-	runTwoPartyTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
+	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
 		setups = NewSetups(rng, []string{"Alice", "Bob"})
 		roles = [2]ctest.Executer{
 			ctest.NewAlice(t, setups[0]),


### PR DESCRIPTION
Adds an app-channel test to go-perun core, which was previously only run in the Ethereum backend.