### PR TITLE
Dispute test: Use e.Version instead e.State.Version

### DIFF
--- a/client/test/carol.go
+++ b/client/test/carol.go
@@ -75,11 +75,11 @@ func (r *Carol) exec(_cfg ExecConfig, ch *paymentChannel, propHandler *acceptNex
 
 	r.log.Debug("Waiting for registered event that will be triggered by mallory registering older state")
 	e := <-r.registered
-	r.log.Debugf("mallory registered the version: %v", e.State.Version)
+	r.log.Debugf("mallory registered the version: %v", e.Version())
 
 	r.log.Debug("Waiting for registered event that will be watcher refuting with the latest state")
 	e = <-r.registered
-	r.log.Debugf("watcher refuted with the version: %v", e.State.Version)
+	r.log.Debugf("watcher refuted with the version: %v", e.Version())
 
 	r.log.Debug("Waiting until ready to conclude")
 	assert.NoError(e.Timeout().Wait(r.Ctx())) // wait until ready to conclude


### PR DESCRIPTION
This removes the dependency on the availability of `e.State` in the app channel tests, which is a feature otherwise only necessary for the virtual channel protocol.