### PR TITLE
Client tests: fail on error

### DIFF
--- a/client/appchannel_test.go
+++ b/client/appchannel_test.go
@@ -19,7 +19,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"perun.network/go-perun/channel"
 	chtest "perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
@@ -32,7 +31,7 @@ import (
 func TestProgression(t *testing.T) {
 	rng := pkgtest.Prng(t)
 
-	setups := NewSetups(rng, []string{"Paul", "Paula"})
+	setups, errs := NewSetups(rng, []string{"Paul", "Paula"})
 	roles := [2]clienttest.Executer{
 		clienttest.NewPaul(t, setups[0]),
 		clienttest.NewPaula(t, setups[1]),
@@ -53,6 +52,5 @@ func TestProgression(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	err := clienttest.ExecuteTwoPartyTest(ctx, roles, execConfig)
-	assert.NoError(t, err)
+	clienttest.ExecuteTwoPartyTest(ctx, t, roles, execConfig, errs)
 }

--- a/client/client_persistence_test.go
+++ b/client/client_persistence_test.go
@@ -27,8 +27,8 @@ func TestPersistencePetraRobert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 
-	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
-		setups = NewSetupsPersistence(t, rng, []string{"Petra", "Robert"})
+	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer, errs chan error) {
+		setups, errs = NewSetupsPersistence(t, rng, []string{"Petra", "Robert"})
 		roles = [2]ctest.Executer{
 			ctest.NewPetra(t, setups[0]),
 			ctest.NewRobert(t, setups[1]),
@@ -37,11 +37,11 @@ func TestPersistencePetraRobert(t *testing.T) {
 	})
 }
 
-func NewSetupsPersistence(t *testing.T, rng *rand.Rand, names []string) []ctest.RoleSetup {
+func NewSetupsPersistence(t *testing.T, rng *rand.Rand, names []string) ([]ctest.RoleSetup, chan error) {
 	t.Helper()
-	setups := NewSetups(rng, names)
+	setups, errs := NewSetups(rng, names)
 	for i := range names {
 		setups[i].PR = chprtest.NewPersistRestorer(t)
 	}
-	return setups
+	return setups, errs
 }

--- a/client/dispute_test.go
+++ b/client/dispute_test.go
@@ -19,7 +19,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	chtest "perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
 	ctest "perun.network/go-perun/client/test"
@@ -33,7 +32,7 @@ func TestDispute(t *testing.T) {
 	defer cancel()
 
 	const mallory, carol = 0, 1 // Indices of Mallory and Carol
-	setups := NewSetups(rng, []string{"Mallory", "Carol"})
+	setups, errs := NewSetups(rng, []string{"Mallory", "Carol"})
 	roles := [2]ctest.Executer{
 		ctest.NewMallory(t, setups[0]),
 		ctest.NewCarol(t, setups[1]),
@@ -49,6 +48,5 @@ func TestDispute(t *testing.T) {
 		NumPayments: [2]int{5, 0},
 		TxAmounts:   [2]*big.Int{big.NewInt(20), big.NewInt(0)},
 	}
-	err := ctest.ExecuteTwoPartyTest(ctx, roles, cfg)
-	assert.NoError(t, err)
+	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg, errs)
 }

--- a/client/happy_test.go
+++ b/client/happy_test.go
@@ -26,8 +26,8 @@ func TestHappyAliceBob(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 
-	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
-		setups = NewSetups(rng, []string{"Alice", "Bob"})
+	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer, errs chan error) {
+		setups, errs = NewSetups(rng, []string{"Alice", "Bob"})
 		roles = [2]ctest.Executer{
 			ctest.NewAlice(t, setups[0]),
 			ctest.NewBob(t, setups[1]),

--- a/client/subchannel_dispute_test.go
+++ b/client/subchannel_dispute_test.go
@@ -19,7 +19,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	chtest "perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
 	ctest "perun.network/go-perun/client/test"
@@ -30,7 +29,7 @@ import (
 func TestSubChannelDispute(t *testing.T) {
 	rng := test.Prng(t)
 
-	setups := NewSetups(rng, []string{"DisputeSusie", "DisputeTim"})
+	setups, errs := NewSetups(rng, []string{"DisputeSusie", "DisputeTim"})
 	roles := [2]ctest.Executer{
 		ctest.NewDisputeSusie(t, setups[0]),
 		ctest.NewDisputeTim(t, setups[1]),
@@ -50,5 +49,5 @@ func TestSubChannelDispute(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	assert.NoError(t, ctest.ExecuteTwoPartyTest(ctx, roles, cfg))
+	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg, errs)
 }

--- a/client/subchannel_happy_test.go
+++ b/client/subchannel_happy_test.go
@@ -19,7 +19,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"perun.network/go-perun/apps/payment"
 	chtest "perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
@@ -31,7 +30,7 @@ import (
 func TestSubChannelHappy(t *testing.T) {
 	rng := test.Prng(t)
 
-	setups := NewSetups(rng, []string{"Susie", "Tim"})
+	setups, errs := NewSetups(rng, []string{"Susie", "Tim"})
 	roles := [2]ctest.Executer{
 		ctest.NewSusie(t, setups[0]),
 		ctest.NewTim(t, setups[1]),
@@ -63,5 +62,5 @@ func TestSubChannelHappy(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	assert.NoError(t, ctest.ExecuteTwoPartyTest(ctx, roles, cfg))
+	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg, errs)
 }

--- a/client/test/carol.go
+++ b/client/test/carol.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"perun.network/go-perun/channel"
 )
 
@@ -53,7 +51,6 @@ func (r *Carol) Execute(cfg ExecConfig) {
 
 func (r *Carol) exec(_cfg ExecConfig, ch *paymentChannel, propHandler *acceptNextPropHandler) {
 	cfg := _cfg.(*MalloryCarolExecConfig)
-	assert := assert.New(r.t)
 	_, them := r.Idxs(cfg.Peers())
 
 	// start watcher
@@ -82,7 +79,7 @@ func (r *Carol) exec(_cfg ExecConfig, ch *paymentChannel, propHandler *acceptNex
 	r.log.Debugf("watcher refuted with the version: %v", e.Version())
 
 	r.log.Debug("Waiting until ready to conclude")
-	assert.NoError(e.Timeout().Wait(r.Ctx())) // wait until ready to conclude
+	r.RequireNoError(e.Timeout().Wait(r.Ctx())) // wait until ready to conclude
 
 	r.log.Debug("Settle")
 	ch.settle() // conclude and withdraw

--- a/client/test/progression.go
+++ b/client/test/progression.go
@@ -18,8 +18,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/log"
 )
@@ -83,7 +81,6 @@ func (r *Paul) Execute(cfg ExecConfig) {
 }
 
 func (r *Paul) exec(_cfg ExecConfig, ch *paymentChannel) {
-	assert := assert.New(r.t)
 	ctx := r.Ctx()
 	assetIdx := 0
 
@@ -97,7 +94,7 @@ func (r *Paul) exec(_cfg ExecConfig, ch *paymentChannel) {
 	r.waitStage() // wait for setup complete
 
 	// progress
-	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) {
+	r.RequireNoError(ch.ForceUpdate(ctx, func(s *channel.State) {
 		bal := func(user channel.Index) int64 {
 			return s.Balances[assetIdx][user].Int64()
 		}
@@ -109,17 +106,17 @@ func (r *Paul) exec(_cfg ExecConfig, ch *paymentChannel) {
 	// Await progressed event 1.
 	r.log.Debugf("%v awaiting progressed event 1", r.setup.Name)
 	e := <-r.progressed
-	assert.Truef(e.Version() == 1, "expected version 1, got version %v", e.Version())
+	r.RequireTruef(e.Version() == 1, "expected version 1, got version %v", e.Version())
 	r.waitStage()
 
 	// Await progressed event 2.
 	r.log.Debugf("%v awaiting progressed event 2", r.setup.Name)
 	e = <-r.progressed
-	assert.Truef(e.Version() == 2, "expected version 2, got version %v", e.Version()) //nolint:gomnd
+	r.RequireTruef(e.Version() == 2, "expected version 2, got version %v", e.Version()) //nolint:gomnd
 	r.waitStage()
 
 	// withdraw
-	assert.NoError(ch.Settle(ctx, false))
+	r.RequireNoError(ch.Settle(ctx, false))
 }
 
 // ----------------- BEGIN PAULA -----------------
@@ -146,7 +143,6 @@ func (r *Paula) Execute(cfg ExecConfig) {
 }
 
 func (r *Paula) exec(_cfg ExecConfig, ch *paymentChannel, _ *acceptNextPropHandler) {
-	assert := assert.New(r.t)
 	ctx := r.Ctx()
 	assetIdx := 0
 
@@ -162,11 +158,11 @@ func (r *Paula) exec(_cfg ExecConfig, ch *paymentChannel, _ *acceptNextPropHandl
 	// Await progressed event 1.
 	r.log.Debugf("%v awaiting progressed event 1", r.setup.Name)
 	e := <-r.progressed
-	assert.Truef(e.Version() == 1, "expected version 1, got version %v", e.Version())
+	r.RequireTruef(e.Version() == 1, "expected version 1, got version %v", e.Version())
 	r.waitStage()
 
 	// we progress
-	assert.NoError(ch.ForceUpdate(ctx, func(s *channel.State) {
+	r.RequireNoError(ch.ForceUpdate(ctx, func(s *channel.State) {
 		bal := func(user channel.Index) int64 {
 			return s.Balances[assetIdx][user].Int64()
 		}
@@ -178,12 +174,12 @@ func (r *Paula) exec(_cfg ExecConfig, ch *paymentChannel, _ *acceptNextPropHandl
 	// Await progressed event 2.
 	r.log.Debugf("%v awaiting progressed event 2", r.setup.Name)
 	e = <-r.progressed
-	assert.Truef(e.Version() == 2, "expected version 2, got version %v", e.Version()) //nolint:gomnd
+	r.RequireTruef(e.Version() == 2, "expected version 2, got version %v", e.Version()) //nolint:gomnd
 	r.waitStage()
 
 	// await ready to conclude
-	assert.NoError(e.Timeout().Wait(ctx), "waiting for progression timeout")
+	r.RequireNoErrorf(e.Timeout().Wait(ctx), "waiting for progression timeout")
 
 	// withdraw
-	assert.NoError(ch.Settle(ctx, true))
+	r.RequireNoError(ch.Settle(ctx, true))
 }

--- a/client/test/proposer.go
+++ b/client/test/proposer.go
@@ -16,9 +16,6 @@ package test
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	pkgtest "polycry.pt/poly-go/test"
 )
 
 // Proposer is a test client role. He proposes the new channel.
@@ -34,20 +31,19 @@ func NewProposer(t *testing.T, setup RoleSetup, numStages int) *Proposer {
 
 // Execute executes the Proposer protocol.
 func (r *Proposer) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChannel)) {
-	rng := pkgtest.Prng(r.t, "proposer")
-	assert := assert.New(r.t)
+	rng := r.NewRng()
 
 	// ignore proposal handler since Proposer doesn't accept any incoming channels
 	_, waitHandler := r.GoHandle(rng)
 	defer func() {
-		assert.NoError(r.Close())
+		r.RequireNoError(r.Close())
 		waitHandler()
 	}()
 
 	prop := r.LedgerChannelProposal(rng, cfg)
 	ch, err := r.ProposeChannel(prop)
-	assert.NoError(err)
-	assert.NotNil(ch)
+	r.RequireNoError(err)
+	r.RequireTrue(ch != nil)
 	if err != nil {
 		return
 	}
@@ -55,5 +51,5 @@ func (r *Proposer) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChannel
 
 	exec(cfg, ch)
 
-	assert.NoError(ch.Close()) // May or may not already be closed due to channelConn closing.
+	r.RequireNoError(ch.Close()) // May or may not already be closed due to channelConn closing.
 }

--- a/client/test/responder.go
+++ b/client/test/responder.go
@@ -16,9 +16,6 @@ package test
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	pkgtest "polycry.pt/poly-go/test"
 )
 
 // Responder is a test client role. He accepts an incoming channel proposal.
@@ -34,19 +31,18 @@ func NewResponder(t *testing.T, setup RoleSetup, numStages int) *Responder {
 
 // Execute executes the Responder protocol.
 func (r *Responder) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChannel, *acceptNextPropHandler)) {
-	rng := pkgtest.Prng(r.t, "responder")
-	assert := assert.New(r.t)
+	rng := r.NewRng()
 
 	propHandler, waitHandler := r.GoHandle(rng)
 	defer func() {
-		assert.NoError(r.Close())
+		r.RequireNoError(r.Close())
 		waitHandler()
 	}()
 
 	// receive one accepted proposal
 	ch, err := propHandler.Next()
-	assert.NoError(err)
-	assert.NotNil(ch)
+	r.RequireNoError(err)
+	r.RequireTrue(ch != nil)
 	if err != nil {
 		return
 	}
@@ -55,5 +51,5 @@ func (r *Responder) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChanne
 
 	exec(cfg, ch, propHandler)
 
-	assert.NoError(ch.Close())
+	r.RequireNoError(ch.Close())
 }

--- a/client/test/subchannel.go
+++ b/client/test/subchannel.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"perun.network/go-perun/client"
-	pkgtest "polycry.pt/poly-go/test"
 )
 
 // SusieTimExecConfig contains config parameters for Susie and Tim test.
@@ -71,7 +70,7 @@ func (r *Susie) Execute(cfg ExecConfig) {
 
 func (r *Susie) exec(_cfg ExecConfig, ledgerChannel *paymentChannel) {
 	cfg := _cfg.(*SusieTimExecConfig)
-	rng := pkgtest.Prng(r.t, "susie")
+	rng := r.NewRng()
 
 	// stage 1 - channel controller set up
 	r.waitStage()

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -149,7 +149,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	vct.errs = make(chan error, 10)
 
 	// Setup clients.
-	clients := NewClients(
+	clients, _ := NewClients(
 		t,
 		rng,
 		[]string{"Alice", "Bob", "Ingrid"},


### PR DESCRIPTION
Client tests involve concurrency. t.FailNow is not available there.
That's why we often used assert instead of require. Now we can use
role.Require.