### PR TITLE
Satisfy linter

### DIFF
--- a/channel/mock_app.go
+++ b/channel/mock_app.go
@@ -116,17 +116,29 @@ func (a MockApp) NewData() Data {
 
 // ValidTransition checks the transition for validity.
 func (a MockApp) ValidTransition(params *Params, from, to *State, actor Index) error {
-	return a.execMockOp(from.Data.(*MockOp))
+	op, ok := from.Data.(*MockOp)
+	if !ok {
+		return fmt.Errorf("wrong data type: expected *MockOp, got %T", from.Data)
+	}
+	return a.execMockOp(op)
 }
 
 // ValidInit checks the initial state for validity.
 func (a MockApp) ValidInit(params *Params, state *State) error {
-	return a.execMockOp(state.Data.(*MockOp))
+	op, ok := state.Data.(*MockOp)
+	if !ok {
+		return fmt.Errorf("wrong data type: expected *MockOp, got %T", state.Data)
+	}
+	return a.execMockOp(op)
 }
 
 // ValidAction checks the action for validity.
 func (a MockApp) ValidAction(params *Params, state *State, part Index, act Action) error {
-	return a.execMockOp(act.(*MockOp))
+	op, ok := act.(*MockOp)
+	if !ok {
+		return fmt.Errorf("wrong data type: expected *MockOp, got %T", act)
+	}
+	return a.execMockOp(op)
 }
 
 // ApplyActions applies the actions unto a copy of state and returns the result or an error.
@@ -134,12 +146,22 @@ func (a MockApp) ApplyActions(params *Params, state *State, acts []Action) (*Sta
 	ret := state.Clone()
 	ret.Version++
 
-	return ret, a.execMockOp(acts[0].(*MockOp))
+	op, ok := acts[0].(*MockOp)
+	if !ok {
+		return nil, fmt.Errorf("wrong data type: expected *MockOp, got %T", acts[0])
+	}
+
+	return ret, a.execMockOp(op)
 }
 
 // InitState Checks for the validity of the passed arguments as initial state.
 func (a MockApp) InitState(params *Params, rawActs []Action) (Allocation, Data, error) {
-	return Allocation{}, nil, a.execMockOp(rawActs[0].(*MockOp))
+	op, ok := rawActs[0].(*MockOp)
+	if !ok {
+		return Allocation{}, nil, fmt.Errorf("wrong data type: expected *MockOp, got %T", rawActs[0])
+	}
+
+	return Allocation{}, nil, a.execMockOp(op)
 }
 
 // execMockOp executes the operation indicated by the MockOp from the MockOp.

--- a/channel/persistence/keyvalue/restorer.go
+++ b/channel/persistence/keyvalue/restorer.go
@@ -160,7 +160,7 @@ func eatExpect(r io.Reader, tok string) error {
 		return errors.WithMessage(err, "reading")
 	}
 	if string(buf) != tok {
-		return errors.Errorf("expected %s, got %s.", tok, string(buf))
+		return errors.Errorf("expected %s, got %s", tok, string(buf))
 	}
 	return nil
 }

--- a/channel/persistence/test/channel.go
+++ b/channel/persistence/test/channel.go
@@ -37,7 +37,7 @@ type Channel struct {
 	*persistence.StateMachine
 
 	pr  persistence.PersistRestorer
-	ctx context.Context
+	ctx context.Context //nolint:containedctx // This is just done for testing. Could be revised.
 }
 
 // NewRandomChannel creates a random channel with the requested persister and

--- a/channel/persistence/test/persistrestorertest.go
+++ b/channel/persistence/test/persistrestorertest.go
@@ -36,7 +36,7 @@ type Client struct {
 
 	rng *rand.Rand
 	pr  persistence.PersistRestorer
-	ctx context.Context
+	ctx context.Context //nolint:containedctx // This is just done for testing. Could be revised.
 }
 
 // number of peers in a channel that are used for the tests.

--- a/client/proposalopts.go
+++ b/client/proposalopts.go
@@ -32,7 +32,11 @@ var optNames = struct{ nonce, app, appData, fundingAgreement string }{nonce: "no
 // App returns the option's configured app.
 func (o ProposalOpts) App() channel.App {
 	if v := o[optNames.app]; v != nil {
-		return v.(channel.App)
+		app, ok := v.(channel.App)
+		if !ok {
+			log.Panicf("wrong type: expected channel.App, got %T", v)
+		}
+		return app
 	}
 	return channel.NoApp()
 }
@@ -40,7 +44,11 @@ func (o ProposalOpts) App() channel.App {
 // AppData returns the option's configured app data.
 func (o ProposalOpts) AppData() channel.Data {
 	if v := o[optNames.appData]; v != nil {
-		return v.(channel.Data)
+		data, ok := v.(channel.Data)
+		if !ok {
+			log.Panicf("wrong type: expected channel.Data, got %T", v)
+		}
+		return data
 	}
 	return channel.NoData()
 }
@@ -63,7 +71,11 @@ func (o ProposalOpts) fundingAgreement() channel.Balances {
 	if !ok {
 		panic("Option FundingAgreement not set")
 	}
-	return a.(channel.Balances)
+	bals, ok := a.(channel.Balances)
+	if !ok {
+		log.Panicf("wrong type: expected channel.Balances, got %T", a)
+	}
+	return bals
 }
 
 // nonce returns the option's configured nonce share, or a random nonce share.
@@ -73,7 +85,11 @@ func (o ProposalOpts) nonce() NonceShare {
 		n = WithRandomNonce().nonce()
 		o[optNames.nonce] = n
 	}
-	return n.(NonceShare)
+	share, ok := n.(NonceShare)
+	if !ok {
+		log.Panicf("wrong type: expected NonceShare, got %T", n)
+	}
+	return share
 }
 
 // isNonce returns whether a ProposalOpts contains a manually set nonce.

--- a/client/sync.go
+++ b/client/sync.go
@@ -73,7 +73,8 @@ func (c *Client) syncChannel(ctx context.Context, ch *persistence.Channel, p wir
 	defer recv.Close() // ignore error
 	id := ch.ID()
 	err = c.conn.Subscribe(recv, func(m *wire.Envelope) bool {
-		return m.Msg.Type() == wire.ChannelSync && m.Msg.(ChannelMsg).ID() == id
+		msg, ok := m.Msg.(*ChannelSyncMsg)
+		return ok && msg.ID() == id
 	})
 	if err != nil {
 		return errors.WithMessage(err, "subscribing on relay")

--- a/client/test/backend.go
+++ b/client/test/backend.go
@@ -396,7 +396,7 @@ func (b *MockBackend) removeSubscription(ch channel.ID, sub *MockSubscription) {
 
 // MockSubscription is a subscription for MockBackend.
 type MockSubscription struct {
-	ctx     context.Context
+	ctx     context.Context //nolint:containedctx // This is just done for testing. Could be revised.
 	events  chan channel.AdjudicatorEvent
 	err     chan error
 	onClose func()

--- a/client/update.go
+++ b/client/update.go
@@ -411,8 +411,7 @@ func (c *Channel) OnUpdate(cb func(from, to *channel.State)) {
 // * Sub-allocations do not change.
 func (c *Channel) validTwoPartyUpdate(up ChannelUpdate, sigIdx channel.Index) error {
 	if up.ActorIdx != sigIdx {
-		return errors.Errorf(
-			"Currently, only update proposals with the proposing peer as actor are allowed.")
+		return errors.New("invalid proposer")
 	}
 	if err := channel.SubAllocsAssertEqual(c.machine.State().Locked, up.State.Locked); err != nil {
 		return errors.WithMessage(err, "sub-allocation changed")

--- a/wire/cache.go
+++ b/wire/cache.go
@@ -52,16 +52,16 @@ func (c *Cache) Release(p *Predicate) {
 // If it matches several predicates, it is still only added once to the cache.
 func (c *Cache) Put(e *Envelope) bool {
 	// we filter the predicates for non-active and lazily remove them
-	any := false
+	found := false
 	for p := range c.preds {
-		any = any || (*p)(e)
+		found = found || (*p)(e)
 	}
 
-	if any {
+	if found {
 		c.msgs = append(c.msgs, e)
 	}
 
-	return any
+	return found
 }
 
 // Messages retrieves all messages from the cache that match the predicate. They are

--- a/wire/relay.go
+++ b/wire/relay.go
@@ -160,15 +160,15 @@ func (p *Relay) Put(e *Envelope) {
 		return
 	}
 
-	any := false
+	found := false
 	for _, sub := range p.consumers {
 		if sub.predicate(e) {
 			sub.consumer.Put(e)
-			any = true
+			found = true
 		}
 	}
 
-	if !any {
+	if !found {
 		if !p.cache.Put(e) {
 			p.defaultMsgHandler(e)
 		}


### PR DESCRIPTION
My local version of golangci for some reason reports more than our CI. Goal of this PR: Satisfy local and remote golangci.

depends on #341 