### PR TITLE
:art: client/test: Reduce setup complexity

### DIFF
--- a/client/appchannel_test.go
+++ b/client/appchannel_test.go
@@ -31,7 +31,7 @@ import (
 func TestProgression(t *testing.T) {
 	rng := pkgtest.Prng(t)
 
-	setups, errs := NewSetups(rng, []string{"Paul", "Paula"})
+	setups := NewSetups(rng, []string{"Paul", "Paula"})
 	roles := [2]clienttest.Executer{
 		clienttest.NewPaul(t, setups[0]),
 		clienttest.NewPaula(t, setups[1]),
@@ -52,5 +52,5 @@ func TestProgression(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	clienttest.ExecuteTwoPartyTest(ctx, t, roles, execConfig, errs)
+	clienttest.ExecuteTwoPartyTest(ctx, t, roles, execConfig)
 }

--- a/client/client_persistence_test.go
+++ b/client/client_persistence_test.go
@@ -27,8 +27,8 @@ func TestPersistencePetraRobert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 
-	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer, errs chan error) {
-		setups, errs = NewSetupsPersistence(t, rng, []string{"Petra", "Robert"})
+	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer) {
+		setups = NewSetupsPersistence(t, rng, []string{"Petra", "Robert"})
 		roles = [2]ctest.Executer{
 			ctest.NewPetra(t, setups[0]),
 			ctest.NewRobert(t, setups[1]),
@@ -37,11 +37,11 @@ func TestPersistencePetraRobert(t *testing.T) {
 	})
 }
 
-func NewSetupsPersistence(t *testing.T, rng *rand.Rand, names []string) ([]ctest.RoleSetup, chan error) {
+func NewSetupsPersistence(t *testing.T, rng *rand.Rand, names []string) []ctest.RoleSetup {
 	t.Helper()
-	setups, errs := NewSetups(rng, names)
+	setups := NewSetups(rng, names)
 	for i := range names {
 		setups[i].PR = chprtest.NewPersistRestorer(t)
 	}
-	return setups, errs
+	return setups
 }

--- a/client/dispute_test.go
+++ b/client/dispute_test.go
@@ -32,7 +32,7 @@ func TestDispute(t *testing.T) {
 	defer cancel()
 
 	const mallory, carol = 0, 1 // Indices of Mallory and Carol
-	setups, errs := NewSetups(rng, []string{"Mallory", "Carol"})
+	setups := NewSetups(rng, []string{"Mallory", "Carol"})
 	roles := [2]ctest.Executer{
 		ctest.NewMallory(t, setups[0]),
 		ctest.NewCarol(t, setups[1]),
@@ -48,5 +48,5 @@ func TestDispute(t *testing.T) {
 		NumPayments: [2]int{5, 0},
 		TxAmounts:   [2]*big.Int{big.NewInt(20), big.NewInt(0)},
 	}
-	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg, errs)
+	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg)
 }

--- a/client/happy_test.go
+++ b/client/happy_test.go
@@ -26,12 +26,12 @@ func TestHappyAliceBob(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 
-	runAliceBobTest(ctx, t, func(rng *rand.Rand) (setups []ctest.RoleSetup, roles [2]ctest.Executer, errs chan error) {
-		setups, errs = NewSetups(rng, []string{"Alice", "Bob"})
-		roles = [2]ctest.Executer{
+	runAliceBobTest(ctx, t, func(rng *rand.Rand) ([]ctest.RoleSetup, [2]ctest.Executer) {
+		setups := NewSetups(rng, []string{"Alice", "Bob"})
+		roles := [2]ctest.Executer{
 			ctest.NewAlice(t, setups[0]),
 			ctest.NewBob(t, setups[1]),
 		}
-		return
+		return setups, roles
 	})
 }

--- a/client/subchannel_dispute_test.go
+++ b/client/subchannel_dispute_test.go
@@ -29,7 +29,7 @@ import (
 func TestSubChannelDispute(t *testing.T) {
 	rng := test.Prng(t)
 
-	setups, errs := NewSetups(rng, []string{"DisputeSusie", "DisputeTim"})
+	setups := NewSetups(rng, []string{"DisputeSusie", "DisputeTim"})
 	roles := [2]ctest.Executer{
 		ctest.NewDisputeSusie(t, setups[0]),
 		ctest.NewDisputeTim(t, setups[1]),
@@ -49,5 +49,5 @@ func TestSubChannelDispute(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg, errs)
+	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg)
 }

--- a/client/subchannel_happy_test.go
+++ b/client/subchannel_happy_test.go
@@ -30,7 +30,7 @@ import (
 func TestSubChannelHappy(t *testing.T) {
 	rng := test.Prng(t)
 
-	setups, errs := NewSetups(rng, []string{"Susie", "Tim"})
+	setups := NewSetups(rng, []string{"Susie", "Tim"})
 	roles := [2]ctest.Executer{
 		ctest.NewSusie(t, setups[0]),
 		ctest.NewTim(t, setups[1]),
@@ -62,5 +62,5 @@ func TestSubChannelHappy(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg, errs)
+	ctest.ExecuteTwoPartyTest(ctx, t, roles, cfg)
 }

--- a/client/test/persistence.go
+++ b/client/test/persistence.go
@@ -209,6 +209,11 @@ func (r *multiClientRole) assertPersistedPeerAndChannel(cfg ExecConfig, state *c
 	r.RequireNoError(restoredCh.CurrentTXV.State.Equal(state))
 }
 
+// Errors returns the error channel.
+func (r *multiClientRole) Errors() <-chan error {
+	return r.errs
+}
+
 type addresses []wire.Address
 
 func (a addresses) contains(b wire.Address) bool {

--- a/client/test/proposer.go
+++ b/client/test/proposer.go
@@ -53,3 +53,8 @@ func (r *Proposer) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChannel
 
 	r.RequireNoError(ch.Close()) // May or may not already be closed due to channelConn closing.
 }
+
+// Errors returns the error channel.
+func (r *Proposer) Errors() <-chan error {
+	return r.errs
+}

--- a/client/test/responder.go
+++ b/client/test/responder.go
@@ -53,3 +53,8 @@ func (r *Responder) Execute(cfg ExecConfig, exec func(ExecConfig, *paymentChanne
 
 	r.RequireNoError(ch.Close())
 }
+
+// Errors returns the error channel.
+func (r *Responder) Errors() <-chan error {
+	return r.errs
+}

--- a/client/test/role.go
+++ b/client/test/role.go
@@ -104,6 +104,8 @@ type (
 		EnableStages() Stages
 		// SetStages enables role synchronization using the given stages.
 		SetStages(Stages)
+		// Errors returns the error channel.
+		Errors() <-chan error
 	}
 
 	// Stages are used to synchronize multiple roles.
@@ -111,7 +113,7 @@ type (
 )
 
 // ExecuteTwoPartyTest executes the specified client test.
-func ExecuteTwoPartyTest(ctx context.Context, t *testing.T, role [2]Executer, cfg ExecConfig, errs chan error) {
+func ExecuteTwoPartyTest(ctx context.Context, t *testing.T, role [2]Executer, cfg ExecConfig) {
 	t.Helper()
 	log.Info("Starting two-party test")
 	defer log.Info("Two-party test done")
@@ -136,7 +138,9 @@ func ExecuteTwoPartyTest(ctx context.Context, t *testing.T, role [2]Executer, cf
 	case <-wg.WaitCh():
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
-	case err := <-errs:
+	case err := <-role[0].Errors():
+		t.Fatal(err)
+	case err := <-role[1].Errors():
 		t.Fatal(err)
 	}
 }

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -149,7 +149,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	vct.errs = make(chan error, 10)
 
 	// Setup clients.
-	clients, _ := NewClients(
+	clients := NewClients(
 		t,
 		rng,
 		[]string{"Alice", "Bob", "Ingrid"},


### PR DESCRIPTION
Previously, we introduced error channels for immediate error handling.
However, this was done at the expense of requiring an additional error
channel parameter during testing setup, which made it more complicated
to setup a client test. Now the error channels are kept only with the
role and the changes to the setup function parameters are reverted.