### PR TITLE
Settle channel when funding fails (Variant B)

### DIFF
--- a/channel/funder.go
+++ b/channel/funder.go
@@ -31,10 +31,9 @@ type (
 		// because a peer did not fund the channel in time.
 		// Depending on the funding protocol, if we fund first and then the peer does
 		// not fund in time, a dispute process needs to be initiated to get back the
-		// funds from the partially funded channel. In this case, the user should
-		// return a PeerTimedOutFundingError containing the index of the peer who
-		// did not fund in time. The framework will then initiate the dispute
-		// process.
+		// funds from the partially funded channel. In this case, it should
+		// return a FundingTimeoutError containing the index of the peer who
+		// did not fund in time.
 		Fund(context.Context, FundingReq) error
 	}
 

--- a/client/client_role_test.go
+++ b/client/client_role_test.go
@@ -75,9 +75,8 @@ type Client struct {
 	ctest.RoleSetup
 }
 
-func NewClients(t *testing.T, rng *rand.Rand, names []string) []*Client {
+func NewClients(t *testing.T, rng *rand.Rand, setups []ctest.RoleSetup) []*Client {
 	t.Helper()
-	setups := NewSetups(rng, names)
 	clients := make([]*Client, len(setups))
 	for i, setup := range setups {
 		setup.Identity = setup.Wallet.NewRandomAccount(rng)

--- a/client/failing_funding_test.go
+++ b/client/failing_funding_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"perun.network/go-perun/channel"
+	chtest "perun.network/go-perun/channel/test"
+	"perun.network/go-perun/client"
+	ctest "perun.network/go-perun/client/test"
+	"perun.network/go-perun/wire"
+	"polycry.pt/poly-go/test"
+)
+
+const (
+	fridaIdx     = 0
+	fredIdx      = 1
+	fridaInitBal = 100
+	fredInitBal  = 50
+)
+
+func TestFailingFunding(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
+	defer cancel()
+	rng := test.Prng(t)
+
+	setups := NewSetups(rng, []string{"Frida", "Fred"})
+	// Inject the failing funder for Frida.
+	setups[fridaIdx].Funder = FailingFunder{}
+	clients := NewClients(t, rng, setups)
+	frida, fred := clients[fridaIdx], clients[fredIdx]
+	fridaAddr, fredAddr := frida.Identity.Address(), fred.Identity.Address()
+
+	chsFred := make(chan *client.Channel, 1)
+	errsFred := make(chan error)
+	go fred.Handle(
+		ctest.AlwaysAcceptChannelHandler(ctx, fredAddr, chsFred, errsFred),
+		ctest.AlwaysRejectUpdateHandler(ctx, errsFred),
+	)
+
+	// Create the proposal.
+	asset := chtest.NewRandomAsset(rng)
+	initAlloc := channel.NewAllocation(2, asset)
+	initAlloc.SetAssetBalances(asset, []*big.Int{big.NewInt(fridaInitBal), big.NewInt(fredInitBal)})
+	parts := []wire.Address{fridaAddr, fredAddr}
+	prop, err := client.NewLedgerChannelProposal(
+		challengeDuration,
+		fridaAddr,
+		initAlloc,
+		parts,
+	)
+	require.NoError(t, err, "creating ledger channel proposal")
+
+	// Frida sends the proposal.
+	_, err = frida.ProposeChannel(ctx, prop)
+	// We expect a ChannelFunding
+	cfErr, ok := err.(*client.ChannelFundingError)
+	require.Truef(t, ok, fmt.Sprintf("expexted ChannelFundingError, got %T", err))
+	require.Nil(t, cfErr.SettleError)
+
+	// Fred gets the channel and settle it afterward.
+	var ch *client.Channel
+	select {
+	case ch = <-chsFred:
+	case err = <-errsFred:
+		t.Fatalf("error in proposee go-routine: %v", err)
+	}
+	require.NoError(t, ch.Settle(ctx, true))
+
+	// Test the final balances.
+	fridaFinalBal := frida.BalanceReader.Balance(fridaAddr, asset)
+	assert.Truef(t, fridaFinalBal.Cmp(big.NewInt(fridaInitBal)) == 0, "frida: wrong final balance: got %v, expected %v", fridaFinalBal, fridaInitBal)
+	fredFinalBal := fred.BalanceReader.Balance(fredAddr, asset)
+	assert.Truef(t, fredFinalBal.Cmp(big.NewInt(fredInitBal)) == 0, "fred: wrong final balance: got %v, expected %v", fredFinalBal, fredInitBal)
+}
+
+type FailingFunder struct{}
+
+// Fund returns an error to simulate failed funding.
+func (m FailingFunder) Fund(ctx context.Context, req channel.FundingReq) error {
+	return errors.New("funding failed")
+}

--- a/client/failing_funding_test.go
+++ b/client/failing_funding_test.go
@@ -32,14 +32,14 @@ import (
 	"polycry.pt/poly-go/test"
 )
 
-const (
-	fridaIdx     = 0
-	fredIdx      = 1
-	fridaInitBal = 100
-	fredInitBal  = 50
-)
-
 func TestFailingFunding(t *testing.T) {
+	const (
+		fridaIdx     = 0
+		fredIdx      = 1
+		fridaInitBal = 100
+		fredInitBal  = 50
+	)
+
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
 	rng := test.Prng(t)

--- a/client/failing_funding_test.go
+++ b/client/failing_funding_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,19 +32,15 @@ import (
 
 func TestFailingFunding(t *testing.T) {
 	const (
-		fundTimeout  = 1 * time.Second
-		fridaIdx     = 0
-		fredIdx      = 1
-		fridaInitBal = 100
-		fredInitBal  = 50
+		challengeDuration = 5
+		fridaIdx          = 0
+		fredIdx           = 1
+		fridaInitBal      = 100
+		fredInitBal       = 50
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), twoPartyTestTimeout)
 	defer cancel()
-	// The ctxFundTimeout is used for Fred when accepting the proposal. This
-	// context deadline will exceed since Frida's funding fails.
-	ctxFundTimeout, cancelFundCtx := context.WithTimeout(context.Background(), fundTimeout)
-	defer cancelFundCtx()
 	rng := test.Prng(t)
 
 	setups := NewSetups(rng, []string{"Frida", "Fred"})
@@ -61,7 +56,7 @@ func TestFailingFunding(t *testing.T) {
 	var chHandlerFred client.ProposalHandlerFunc = func(cp client.ChannelProposal, pr *client.ProposalResponder) {
 		switch cp := cp.(type) {
 		case *client.LedgerChannelProposalMsg:
-			ch, err := pr.Accept(ctxFundTimeout, cp.Accept(fredAddr, client.WithRandomNonce()))
+			ch, err := pr.Accept(ctx, cp.Accept(fredAddr, client.WithRandomNonce()))
 			require.Error(t, err)
 			chsFred <- ch
 		default:

--- a/client/failing_funding_test.go
+++ b/client/failing_funding_test.go
@@ -73,12 +73,12 @@ func TestFailingFunding(t *testing.T) {
 
 	// Frida sends the proposal.
 	_, err = frida.ProposeChannel(ctx, prop)
-	// We expect a ChannelFunding
+	// We expect a ChannelFunding error.
 	cfErr, ok := err.(*client.ChannelFundingError)
 	require.Truef(t, ok, fmt.Sprintf("expexted ChannelFundingError, got %T", err))
 	require.Nil(t, cfErr.SettleError)
 
-	// Fred gets the channel and settle it afterward.
+	// Fred gets the channel and settles it afterwards.
 	var ch *client.Channel
 	select {
 	case ch = <-chsFred:

--- a/client/proposal.go
+++ b/client/proposal.go
@@ -75,6 +75,11 @@ type (
 		ItemType string // ItemType indicates the type of item rejected (channel proposal or channel update).
 		Reason   string // Reason sent by the peer for the rejection.
 	}
+
+	// ChannelFundingError indicates an error during channel funding.
+	ChannelFundingError struct {
+		Err error
+	}
 )
 
 // HandleProposal calls the proposal handler function.
@@ -93,16 +98,22 @@ func (f ProposalHandlerFunc) HandleProposal(p ChannelProposal, r *ProposalRespon
 // callback registered with Client.OnNewChannel. Accept returns after this
 // callback has run.
 //
-// It is important that the passed context does not cancel before twice the
-// ChallengeDuration has passed (at least for real blockchain backends with wall
-// time), or the channel cannot be settled if a peer times out funding.
+// It is important that the passed context does not cancel before the
+// ChallengeDuration has passed. Otherwise funding may not complete.
+//
+// If funding fails, ChannelFundingError is thrown and an unfunded channel
+// object is returned, which can be used for withdrawing the funds.
 //
 // After the channel got successfully created, the user is required to start the
 // channel watcher with Channel.Watch() on the returned channel controller.
 //
-// Returns TxTimedoutError when the program times out waiting for a transaction
-// to be mined.
-// Returns ChainNotReachableError if the connection to the blockchain network
+// Returns ChannelFundingError if an error happened during funding. The internal
+// error gives more information.
+// - Contains FundingTimeoutError if any of the participants do not fund the
+// channel in time.
+// - Contains TxTimedoutError when the program times out waiting for a
+// transaction to be mined.
+// - Contains ChainNotReachableError if the connection to the blockchain network
 // fails when sending a transaction to / reading from the blockchain.
 func (r *ProposalResponder) Accept(ctx context.Context, acc ChannelProposalAccept) (*Channel, error) {
 	if ctx == nil {
@@ -136,9 +147,11 @@ func (r *ProposalResponder) Reject(ctx context.Context, reason string) error {
 // callback registered with Client.OnNewChannel. Accept returns after this
 // callback has run.
 //
-// It is important that the passed context does not cancel before twice the
-// ChallengeDuration has passed (at least for real blockchain backends with wall
-// time), or the channel cannot be settled if a peer times out funding.
+// It is important that the passed context does not cancel before the
+// ChallengeDuration has passed. Otherwise funding may not complete.
+//
+// If funding fails, ChannelFundingError is thrown and an unfunded channel
+// object is returned, which can be used for withdrawing the funds.
 //
 // After the channel got successfully created, the user is required to start the
 // channel watcher with Channel.Watch() on the returned channel
@@ -147,11 +160,13 @@ func (r *ProposalResponder) Reject(ctx context.Context, reason string) error {
 // Returns PeerRejectedProposalError if the channel is rejected by the peer.
 // Returns RequestTimedOutError if the peer did not respond before the context
 // expires or is cancelled.
-// Returns FundingTimeoutError if any of the participants do not fund the
+// Returns ChannelFundingError if an error happened during funding. The internal
+// error gives more information.
+// - Contains FundingTimeoutError if any of the participants do not fund the
 // channel in time.
-// Returns TxTimedoutError when the program times out waiting for a transaction
-// to be mined.
-// Returns ChainNotReachableError if the connection to the blockchain network
+// - Contains TxTimedoutError when the program times out waiting for a
+// transaction to be mined.
+// - Contains ChainNotReachableError if the connection to the blockchain network
 // fails when sending a transaction to / reading from the blockchain.
 func (c *Client) ProposeChannel(ctx context.Context, prop ChannelProposal) (*Channel, error) {
 	if ctx == nil {
@@ -182,8 +197,12 @@ func (c *Client) ProposeChannel(ctx context.Context, prop ChannelProposal) (*Cha
 	}
 
 	// 3. fund
-	fundingErr := c.fundChannel(ctx, ch, prop)
-	return ch, fundingErr
+	err = c.fundChannel(ctx, ch, prop)
+	if err != nil {
+		return ch, newChannelFundingError(err)
+	}
+
+	return ch, nil
 }
 
 func (c *Client) prepareChannelOpening(ctx context.Context, prop ChannelProposal, ourIdx channel.Index) (err error) {
@@ -254,8 +273,11 @@ func (c *Client) handleChannelProposalAcc(
 		return ch, errors.WithMessage(err, "accept channel proposal")
 	}
 
-	fundingErr := c.fundChannel(ctx, ch, prop)
-	return ch, fundingErr
+	err = c.fundChannel(ctx, ch, prop)
+	if err != nil {
+		return ch, newChannelFundingError(err)
+	}
+	return ch, nil
 }
 
 func (c *Client) acceptChannelProposal(
@@ -753,4 +775,12 @@ func (e PeerRejectedError) Error() string {
 
 func newPeerRejectedError(rejectedItemType, reason string) error {
 	return errors.WithStack(PeerRejectedError{rejectedItemType, reason})
+}
+
+func newChannelFundingError(err error) *ChannelFundingError {
+	return &ChannelFundingError{err}
+}
+
+func (e ChannelFundingError) Error() string {
+	return fmt.Sprintf("channel funding failed: %v", e.Err.Error())
 }

--- a/client/test/handler.go
+++ b/client/test/handler.go
@@ -32,10 +32,11 @@ func AlwaysAcceptChannelHandler(ctx context.Context, addr wire.Address, channels
 		case *client.LedgerChannelProposalMsg:
 			ch, err := pr.Accept(ctx, cp.Accept(addr, client.WithRandomNonce()))
 			if err != nil {
-				errs <- errors.WithMessage(err, "accepting ledger channel proposal")
-				return
+				errs <- err
 			}
-			channels <- ch
+			if ch != nil {
+				channels <- ch
+			}
 		default:
 			errs <- errors.Errorf("invalid channel proposal: %v", cp)
 		}

--- a/client/test/handler.go
+++ b/client/test/handler.go
@@ -1,0 +1,78 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"perun.network/go-perun/channel"
+	"perun.network/go-perun/client"
+	"perun.network/go-perun/wire"
+)
+
+// AlwaysAcceptChannelHandler returns a channel proposal handler that accepts
+// all channel proposals.
+func AlwaysAcceptChannelHandler(ctx context.Context, addr wire.Address, channels chan *client.Channel, errs chan<- error) client.ProposalHandlerFunc {
+	return func(cp client.ChannelProposal, pr *client.ProposalResponder) {
+		switch cp := cp.(type) {
+		case *client.LedgerChannelProposalMsg:
+			ch, err := pr.Accept(ctx, cp.Accept(addr, client.WithRandomNonce()))
+			if err != nil {
+				errs <- errors.WithMessage(err, "accepting ledger channel proposal")
+				return
+			}
+			channels <- ch
+		default:
+			errs <- errors.Errorf("invalid channel proposal: %v", cp)
+		}
+	}
+}
+
+// AlwaysRejectChannelHandler returns a channel proposal handler that rejects
+// all channel proposals.
+func AlwaysRejectChannelHandler(ctx context.Context, errs chan<- error) client.ProposalHandlerFunc {
+	return func(cp client.ChannelProposal, pr *client.ProposalResponder) {
+		err := pr.Reject(ctx, "not accepting channels")
+		if err != nil {
+			errs <- err
+		}
+	}
+}
+
+// AlwaysAcceptUpdateHandler returns a channel update handler that accepts
+// all channel updates.
+func AlwaysAcceptUpdateHandler(ctx context.Context, errs chan error) client.UpdateHandlerFunc {
+	return func(
+		s *channel.State, cu client.ChannelUpdate, ur *client.UpdateResponder,
+	) {
+		err := ur.Accept(ctx)
+		if err != nil {
+			errs <- errors.WithMessage(err, "accepting channel update")
+		}
+	}
+}
+
+// AlwaysRejectUpdateHandler returns a channel update handler that rejects all
+// channel updates.
+func AlwaysRejectUpdateHandler(ctx context.Context, errs chan error) client.UpdateHandlerFunc {
+	return func(state *channel.State, update client.ChannelUpdate, responder *client.UpdateResponder) {
+		err := responder.Reject(ctx, "")
+		if err != nil {
+			errs <- errors.WithMessage(err, "rejecting channel update")
+		}
+	}
+}

--- a/client/test/multiledger.go
+++ b/client/test/multiledger.go
@@ -16,12 +16,11 @@ package test
 
 import (
 	"bytes"
-	"context"
 	"math/rand"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/multi"
 	chtest "perun.network/go-perun/channel/test"
@@ -167,47 +166,5 @@ func setupClient(
 		Client:      c,
 		WireAddress: acc.Address(),
 		Events:      make(chan channel.AdjudicatorEvent),
-	}
-}
-
-// AlwaysAcceptChannelHandler returns a channel proposal handler that accepts
-// all channel proposals.
-func AlwaysAcceptChannelHandler(ctx context.Context, addr wire.Address, channels chan *client.Channel, errs chan<- error) client.ProposalHandlerFunc {
-	return func(cp client.ChannelProposal, pr *client.ProposalResponder) {
-		switch cp := cp.(type) {
-		case *client.LedgerChannelProposalMsg:
-			ch, err := pr.Accept(ctx, cp.Accept(addr, client.WithRandomNonce()))
-			if err != nil {
-				errs <- errors.WithMessage(err, "accepting ledger channel proposal")
-				return
-			}
-			channels <- ch
-		default:
-			errs <- errors.Errorf("invalid channel proposal: %v", cp)
-		}
-	}
-}
-
-// AlwaysRejectChannelHandler returns a channel proposal handler that rejects
-// all channel proposals.
-func AlwaysRejectChannelHandler(ctx context.Context, errs chan<- error) client.ProposalHandlerFunc {
-	return func(cp client.ChannelProposal, pr *client.ProposalResponder) {
-		err := pr.Reject(ctx, "not accepting channels")
-		if err != nil {
-			errs <- err
-		}
-	}
-}
-
-// AlwaysAcceptUpdateHandler returns a channel update handler that accepts
-// all channel updates.
-func AlwaysAcceptUpdateHandler(ctx context.Context, errs chan error) client.UpdateHandlerFunc {
-	return func(
-		s *channel.State, cu client.ChannelUpdate, ur *client.UpdateResponder,
-	) {
-		err := ur.Accept(ctx)
-		if err != nil {
-			errs <- errors.WithMessage(err, "accepting channel update")
-		}
 	}
 }

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"perun.network/go-perun/channel"
 	chtest "perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
@@ -149,11 +150,8 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	vct.errs = make(chan error, 10)
 
 	// Setup clients.
-	clients := NewClients(
-		t,
-		rng,
-		[]string{"Alice", "Bob", "Ingrid"},
-	)
+	setups := NewSetups(rng, []string{"Alice", "Bob", "Ingrid"})
+	clients := NewClients(t, rng, setups)
 	alice, bob, ingrid := clients[0], clients[1], clients[2]
 	vct.alice, vct.bob, vct.ingrid = alice, bob, ingrid
 	vct.balanceReader = alice.BalanceReader // Assumes all clients have same backend.


### PR DESCRIPTION
This is the second implementation variant where the `ProposeChannel` method does not automatically settle the channel after a failed funding but the client itself has to take care of this.