### PR TITLE
Separate wire address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# Go generate output
-*.bin-runtime

--- a/backend/sim/wire/account.go
+++ b/backend/sim/wire/account.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package wire
 
 import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
+	"math/rand"
+
+	"perun.network/go-perun/wire"
 )
+
+// Account is a wire account.
+type Account struct {
+	addr wire.Address
+}
+
+// Address returns the account's address.
+func (acc *Account) Address() wire.Address {
+	return acc.addr
+}
+
+// NewRandomAccount generates a new random account.
+func NewRandomAccount(rng *rand.Rand) *Account {
+	return &Account{
+		addr: NewRandomAddress(rng),
+	}
+}

--- a/backend/sim/wire/address.go
+++ b/backend/sim/wire/address.go
@@ -43,7 +43,7 @@ func (a *Address) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// Equal returns wether the two addresses are equal.
+// Equal returns whether the two addresses are equal.
 func (a Address) Equal(bIface wire.Address) bool {
 	b, ok := bIface.(*Address)
 	if !ok {

--- a/backend/sim/wire/address.go
+++ b/backend/sim/wire/address.go
@@ -1,0 +1,73 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wire
+
+import (
+	"bytes"
+	"math/rand"
+
+	"perun.network/go-perun/wire"
+)
+
+// AddrLen is the length of an address in byte.
+const AddrLen = 32
+
+// Address is a wire address.
+type Address [AddrLen]byte
+
+// NewAddress returns a new address.
+func NewAddress() *Address {
+	return &Address{}
+}
+
+// MarshalBinary marshals the address to binary.
+func (a Address) MarshalBinary() (data []byte, err error) {
+	return a[:], nil
+}
+
+// UnmarshalBinary unmarshals an address from binary.
+func (a *Address) UnmarshalBinary(data []byte) error {
+	copy(a[:], data)
+	return nil
+}
+
+// Equal returns wether the two addresses are equal.
+func (a Address) Equal(bIface wire.Address) bool {
+	b, ok := bIface.(*Address)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(a[:], b[:])
+}
+
+// Cmp compares the byte representation of two addresses. For `a.Cmp(b)`
+// returns -1 if a < b, 0 if a == b, 1 if a > b.
+func (a Address) Cmp(bIface wire.Address) int {
+	b, ok := bIface.(*Address)
+	if !ok {
+		panic("wrong type")
+	}
+	return bytes.Compare(a[:], b[:])
+}
+
+// NewRandomAddress returns a new random peer address.
+func NewRandomAddress(rng *rand.Rand) *Address {
+	addr := Address{}
+	_, err := rng.Read(addr[:])
+	if err != nil {
+		panic(err)
+	}
+	return &addr
+}

--- a/backend/sim/wire/address.go
+++ b/backend/sim/wire/address.go
@@ -44,22 +44,22 @@ func (a *Address) UnmarshalBinary(data []byte) error {
 }
 
 // Equal returns whether the two addresses are equal.
-func (a Address) Equal(bIface wire.Address) bool {
-	b, ok := bIface.(*Address)
+func (a Address) Equal(b wire.Address) bool {
+	bTyped, ok := b.(*Address)
 	if !ok {
 		return false
 	}
-	return bytes.Equal(a[:], b[:])
+	return bytes.Equal(a[:], bTyped[:])
 }
 
 // Cmp compares the byte representation of two addresses. For `a.Cmp(b)`
 // returns -1 if a < b, 0 if a == b, 1 if a > b.
-func (a Address) Cmp(bIface wire.Address) int {
-	b, ok := bIface.(*Address)
+func (a Address) Cmp(b wire.Address) int {
+	bTyped, ok := b.(*Address)
 	if !ok {
 		panic("wrong type")
 	}
-	return bytes.Compare(a[:], b[:])
+	return bytes.Compare(a[:], bTyped[:])
 }
 
 // NewRandomAddress returns a new random peer address.

--- a/backend/sim/wire/address_test.go
+++ b/backend/sim/wire/address_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package wire_test
 
 import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
+	"math/rand"
+	"testing"
+
+	simwire "perun.network/go-perun/backend/sim/wire"
+	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/test"
 )
+
+func TestAddress(t *testing.T) {
+	test.TestAddressImplementation(t, func() wire.Address {
+		return simwire.NewAddress()
+	}, func(rng *rand.Rand) wire.Address {
+		return simwire.NewRandomAddress(rng)
+	})
+}

--- a/backend/sim/wire/doc.go
+++ b/backend/sim/wire/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2020 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
-
-import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
-)
+// Package wire contains the implementation of the wire interfaces.
+package wire // import "perun.network/go-perun/backend/sim/wire"

--- a/backend/sim/wire/init.go
+++ b/backend/sim/wire/init.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package wire
 
 import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
+	"math/rand"
+
+	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/test"
 )
+
+func init() {
+	wire.SetNewAddressFunc(func() wire.Address {
+		return NewAddress()
+	})
+	test.SetNewRandomAddress(func(rng *rand.Rand) wire.Address {
+		return NewRandomAddress(rng)
+	})
+	test.SetNewRandomAccount(func(rng *rand.Rand) wire.Account {
+		return NewRandomAccount(rng)
+	})
+}

--- a/channel/persistence/keyvalue/persistrestorer_internal_test.go
+++ b/channel/persistence/keyvalue/persistrestorer_internal_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	_ "perun.network/go-perun/backend/sim"
+	_ "perun.network/go-perun/backend/sim" // backend init
 	"perun.network/go-perun/channel/persistence/test"
 	"polycry.pt/poly-go/sortedkv"
 	"polycry.pt/poly-go/sortedkv/leveldb"

--- a/channel/persistence/test/persistrestorertest.go
+++ b/channel/persistence/test/persistrestorertest.go
@@ -25,8 +25,8 @@ import (
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/channel/persistence"
 	"perun.network/go-perun/log"
-	wtest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 
@@ -46,7 +46,7 @@ const channelNumPeers = 2
 func NewClient(ctx context.Context, t *testing.T, rng *rand.Rand, pr persistence.PersistRestorer) *Client {
 	t.Helper()
 	return &Client{
-		addr: wtest.NewRandomAddress(rng),
+		addr: test.NewRandomAddress(rng),
 		rng:  rng,
 		pr:   pr,
 		ctx:  ctx,
@@ -94,7 +94,7 @@ func GenericPersistRestorerTest(
 
 	ct := pkgtest.NewConcurrent(t)
 	c := NewClient(ctx, t, rng, pr)
-	peers := wtest.NewRandomAddresses(rng, numPeers)
+	peers := test.NewRandomAddresses(rng, numPeers)
 
 	channels := make([]map[channel.ID]*Channel, numPeers)
 	var prevCh *Channel

--- a/client/client_role_test.go
+++ b/client/client_role_test.go
@@ -27,6 +27,7 @@ import (
 	chtest "perun.network/go-perun/channel/test"
 	"perun.network/go-perun/client"
 	ctest "perun.network/go-perun/client/test"
+	"perun.network/go-perun/wallet"
 	wtest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/watcher/local"
 	"perun.network/go-perun/wire"
@@ -54,7 +55,7 @@ func NewSetups(rng *rand.Rand, names []string) []ctest.RoleSetup {
 		}
 		setup[i] = ctest.RoleSetup{
 			Name:              names[i],
-			Identity:          wtest.NewRandomAccount(rng),
+			Identity:          wiretest.NewRandomAccount(rng),
 			Bus:               bus,
 			Funder:            backend,
 			Adjudicator:       backend,
@@ -73,18 +74,20 @@ func NewSetups(rng *rand.Rand, names []string) []ctest.RoleSetup {
 type Client struct {
 	*client.Client
 	ctest.RoleSetup
+	WalletAddress wallet.Address
 }
 
 func NewClients(t *testing.T, rng *rand.Rand, setups []ctest.RoleSetup) []*Client {
 	t.Helper()
 	clients := make([]*Client, len(setups))
 	for i, setup := range setups {
-		setup.Identity = setup.Wallet.NewRandomAccount(rng)
+		setup.Identity = wiretest.NewRandomAccount(rng)
 		cl, err := client.New(setup.Identity.Address(), setup.Bus, setup.Funder, setup.Adjudicator, setup.Wallet, setup.Watcher)
 		assert.NoError(t, err)
 		clients[i] = &Client{
-			Client:    cl,
-			RoleSetup: setup,
+			Client:        cl,
+			RoleSetup:     setup,
+			WalletAddress: setup.Wallet.NewRandomAccount(rng).Address(),
 		}
 	}
 	return clients

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -28,6 +28,7 @@ import (
 	wtest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/watcher/local"
 	"perun.network/go-perun/wire"
+	wiretest "perun.network/go-perun/wire/test"
 	"polycry.pt/poly-go/test"
 )
 
@@ -46,7 +47,7 @@ func (d DummyBus) SubscribeClient(wire.Consumer, wire.Address) error {
 
 func TestClient_New_NilArgs(t *testing.T) {
 	rng := test.Prng(t)
-	id := wtest.NewRandomAddress(rng)
+	id := wiretest.NewRandomAddress(rng)
 	backend := &ctest.MockBackend{}
 	b, f, a, w := &DummyBus{t}, backend, backend, wtest.RandomWallet()
 	watcher, err := local.NewWatcher(backend)
@@ -64,7 +65,7 @@ func TestClient_Handle_NilArgs(t *testing.T) {
 	backend := &ctest.MockBackend{}
 	watcher, err := local.NewWatcher(backend)
 	require.NoError(t, err, "initializing the watcher should not error")
-	c, err := client.New(wtest.NewRandomAddress(rng),
+	c, err := client.New(wiretest.NewRandomAddress(rng),
 		&DummyBus{t}, backend, backend, wtest.RandomWallet(), watcher)
 	require.NoError(t, err)
 
@@ -79,7 +80,7 @@ func TestClient_New(t *testing.T) {
 	backend := &ctest.MockBackend{}
 	watcher, err := local.NewWatcher(backend)
 	require.NoError(t, err, "initializing the watcher should not error")
-	c, err := client.New(wtest.NewRandomAddress(rng),
+	c, err := client.New(wiretest.NewRandomAddress(rng),
 		&DummyBus{t}, backend, backend, wtest.RandomWallet(), watcher)
 	assert.NoError(t, err)
 	require.NotNil(t, c)

--- a/client/multiledger_dispute_test.go
+++ b/client/multiledger_dispute_test.go
@@ -53,7 +53,7 @@ func TestMultiLedgerDispute(t *testing.T) {
 	initAlloc.Balances = initBals
 	prop, err := client.NewLedgerChannelProposal(
 		challengeDuration,
-		alice.WireAddress,
+		alice.WalletAddress,
 		initAlloc,
 		parts,
 	)
@@ -67,7 +67,7 @@ func TestMultiLedgerDispute(t *testing.T) {
 		ctest.AlwaysAcceptUpdateHandler(ctx, errs),
 	)
 	go bob.Handle(
-		ctest.AlwaysAcceptChannelHandler(ctx, bob.WireAddress, channels, errs),
+		ctest.AlwaysAcceptChannelHandler(ctx, bob.WalletAddress, channels, errs),
 		ctest.AlwaysAcceptUpdateHandler(ctx, errs),
 	)
 
@@ -117,6 +117,6 @@ func TestMultiLedgerDispute(t *testing.T) {
 	require.NoError(err)
 
 	// Check final balances.
-	require.True(mlt.L1.Balance(mlt.C2.WireAddress, mlt.A1).Cmp(updateBals1[0][1]) == 0)
-	require.True(mlt.L2.Balance(mlt.C2.WireAddress, mlt.A2).Cmp(updateBals1[1][1]) == 0)
+	require.True(mlt.L1.Balance(mlt.C2.WalletAddress, mlt.A1).Cmp(updateBals1[0][1]) == 0)
+	require.True(mlt.L2.Balance(mlt.C2.WalletAddress, mlt.A2).Cmp(updateBals1[1][1]) == 0)
 }

--- a/client/multiledger_happy_test.go
+++ b/client/multiledger_happy_test.go
@@ -56,7 +56,7 @@ func TestMultiLedgerHappy(t *testing.T) {
 	initAlloc.Balances = initBals
 	prop, err := client.NewLedgerChannelProposal(
 		challengeDuration,
-		alice.WireAddress,
+		alice.WalletAddress,
 		initAlloc,
 		parts,
 	)
@@ -70,7 +70,7 @@ func TestMultiLedgerHappy(t *testing.T) {
 		ctest.AlwaysAcceptUpdateHandler(ctx, errs),
 	)
 	go bob.Handle(
-		ctest.AlwaysAcceptChannelHandler(ctx, bob.WireAddress, channels, errs),
+		ctest.AlwaysAcceptChannelHandler(ctx, bob.WalletAddress, channels, errs),
 		ctest.AlwaysAcceptUpdateHandler(ctx, errs),
 	)
 

--- a/client/proposal.go
+++ b/client/proposal.go
@@ -387,7 +387,7 @@ func (c *Client) proposeTwoPartyChannel(
 func (c *Client) validTwoPartyProposal(
 	proposal ChannelProposal,
 	ourIdx channel.Index,
-	peerAddr wallet.Address,
+	peerAddr wire.Address,
 ) error {
 	if err := proposal.Valid(); err != nil {
 		return err

--- a/client/proposal_internal_test.go
+++ b/client/proposal_internal_test.go
@@ -24,7 +24,6 @@ import (
 
 	"perun.network/go-perun/channel"
 	channeltest "perun.network/go-perun/channel/test"
-	"perun.network/go-perun/wallet"
 	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	wiretest "perun.network/go-perun/wire/test"
@@ -36,7 +35,7 @@ func TestClient_validTwoPartyProposal(t *testing.T) {
 
 	// dummy client that only has an id
 	c := &Client{
-		address: wallettest.NewRandomAddress(rng),
+		address: wiretest.NewRandomAddress(rng),
 	}
 	validProp := NewRandomLedgerChannelProposal(rng, channeltest.WithNumParts(2))
 	validProp.Peers[0] = c.address // set us as the proposer
@@ -52,7 +51,7 @@ func TestClient_validTwoPartyProposal(t *testing.T) {
 	tests := []struct {
 		prop     *LedgerChannelProposalMsg
 		ourIdx   channel.Index
-		peerAddr wallet.Address
+		peerAddr wire.Address
 		valid    bool
 	}{
 		{

--- a/client/test/handler.go
+++ b/client/test/handler.go
@@ -21,12 +21,12 @@ import (
 
 	"perun.network/go-perun/channel"
 	"perun.network/go-perun/client"
-	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wallet"
 )
 
 // AlwaysAcceptChannelHandler returns a channel proposal handler that accepts
 // all channel proposals.
-func AlwaysAcceptChannelHandler(ctx context.Context, addr wire.Address, channels chan *client.Channel, errs chan<- error) client.ProposalHandlerFunc {
+func AlwaysAcceptChannelHandler(ctx context.Context, addr wallet.Address, channels chan *client.Channel, errs chan<- error) client.ProposalHandlerFunc {
 	return func(cp client.ChannelProposal, pr *client.ProposalResponder) {
 		switch cp := cp.(type) {
 		case *client.LedgerChannelProposalMsg:

--- a/client/virtual_channel_test.go
+++ b/client/virtual_channel_test.go
@@ -105,11 +105,11 @@ func (vct *virtualChannelTest) testFinalBalancesDispute(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 	backend, asset := vct.balanceReader, vct.asset
-	got, expected := backend.Balance(vct.alice.Identity.Address(), asset), vct.finalBalsAlice[0]
+	got, expected := backend.Balance(vct.alice.WalletAddress, asset), vct.finalBalsAlice[0]
 	assert.Truef(got.Cmp(expected) == 0, "alice: wrong final balance: got %v, expected %v", got, expected)
-	got, expected = backend.Balance(vct.bob.Identity.Address(), asset), vct.finalBalsBob[0]
+	got, expected = backend.Balance(vct.bob.WalletAddress, asset), vct.finalBalsBob[0]
 	assert.Truef(got.Cmp(expected) == 0, "bob: wrong final balance: got %v, expected %v", got, expected)
-	got, expected = backend.Balance(vct.ingrid.Identity.Address(), asset), vct.finalBalIngrid
+	got, expected = backend.Balance(vct.ingrid.WalletAddress, asset), vct.finalBalIngrid
 	assert.Truef(got.Cmp(expected) == 0, "ingrid: wrong final balance: got %v, expected %v", got, expected)
 }
 
@@ -160,7 +160,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	var openingProposalHandlerIngrid client.ProposalHandlerFunc = func(cp client.ChannelProposal, pr *client.ProposalResponder) {
 		switch cp := cp.(type) {
 		case *client.LedgerChannelProposalMsg:
-			ch, err := pr.Accept(ctx, cp.Accept(ingrid.Identity.Address(), client.WithRandomNonce()))
+			ch, err := pr.Accept(ctx, cp.Accept(ingrid.WalletAddress, client.WithRandomNonce()))
 			if err != nil {
 				vct.errs <- errors.WithMessage(err, "accepting ledger channel proposal")
 			}
@@ -181,7 +181,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	initAllocAlice.SetAssetBalances(asset, initBalsAlice)
 	lcpAlice, err := client.NewLedgerChannelProposal(
 		challengeDuration,
-		alice.Identity.Address(),
+		alice.WalletAddress,
 		initAllocAlice,
 		peersAlice,
 	)
@@ -201,7 +201,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	initAllocBob.SetAssetBalances(asset, initBalsBob)
 	lcpBob, err := client.NewLedgerChannelProposal(
 		challengeDuration,
-		bob.Identity.Address(),
+		bob.WalletAddress,
 		initAllocBob,
 		peersBob,
 	)
@@ -222,7 +222,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	) {
 		switch cp := cp.(type) {
 		case *client.VirtualChannelProposalMsg:
-			ch, err := pr.Accept(ctx, cp.Accept(bob.Identity.Address()))
+			ch, err := pr.Accept(ctx, cp.Accept(bob.WalletAddress))
 			if err != nil {
 				vct.errs <- errors.WithMessage(err, "accepting virtual channel proposal")
 			}
@@ -250,7 +250,7 @@ func setupVirtualChannelTest(t *testing.T, ctx context.Context) (vct virtualChan
 	indexMapBob := []channel.Index{1, 0}
 	vcp, err := client.NewVirtualChannelProposal(
 		challengeDuration,
-		alice.Identity.Address(),
+		alice.WalletAddress,
 		&initAllocVirtual,
 		[]wire.Address{alice.Identity.Address(), bob.Identity.Address()},
 		[]channel.ID{vct.chAliceIngrid.ID(), vct.chBobIngrid.ID()},

--- a/wallet/address.go
+++ b/wallet/address.go
@@ -42,9 +42,6 @@ type Address interface {
 	// Equal returns wether the two addresses are equal. The implementation
 	// must be equivalent to checking `Address.Cmp(Address) == 0`.
 	Equal(Address) bool
-	// Cmp compares the byte representation of two addresses. For `a.Cmp(b)`
-	// returns -1 if a < b, 0 if a == b, 1 if a > b.
-	Cmp(Address) int
 }
 
 // IndexOfAddr returns the index of the given address in the address slice,

--- a/wallet/test/address.go
+++ b/wallet/test/address.go
@@ -42,11 +42,6 @@ func TestAddress(t *testing.T, s *Setup) { //nolint:revive // `test.Test...` stu
 	assert.False(t, addr.Equal(null), "Expected inequality of zero, nonzero address")
 	assert.True(t, null.Equal(null), "Expected equality of zero address to itself") //nolint:gocritic
 
-	// Test Address.Cmp.
-	assert.Positive(t, addr.Cmp(null), "Expected addr > zero")
-	assert.Zero(t, null.Cmp(null), "Expected zero = zero") //nolint:gocritic
-	assert.Negative(t, null.Cmp(addr), "Expected null < addr")
-
 	// Test Address.Bytes.
 	addrBytes, err := addr.MarshalBinary()
 	assert.NoError(t, err, "Marshaling address should not error")

--- a/wire/account.go
+++ b/wire/account.go
@@ -16,8 +16,6 @@ package wire
 
 import (
 	"io"
-
-	"perun.network/go-perun/wallet"
 )
 
 func init() {
@@ -29,9 +27,11 @@ func init() {
 }
 
 // Account is a node's permanent Perun identity, which is used to establish
-// authenticity within the Perun peer-to-peer network. For now, it is just a
-// stub.
-type Account = wallet.Account
+// authenticity within the Perun peer-to-peer network.
+type Account interface {
+	// Address used by this account.
+	Address() Address
+}
 
 var _ Msg = (*AuthResponseMsg)(nil)
 

--- a/wire/address.go
+++ b/wire/address.go
@@ -15,6 +15,7 @@
 package wire
 
 import (
+	"encoding"
 	stdio "io"
 
 	"perun.network/go-perun/wallet"
@@ -30,7 +31,15 @@ var (
 // identity within the Perun peer-to-peer network. For now, it is based on type
 // wallet.Address.
 type Address interface {
-	wallet.Address
+	// BinaryMarshaler marshals the address to binary.
+	encoding.BinaryMarshaler
+	// BinaryUnmarshaler unmarshals an address from binary.
+	encoding.BinaryUnmarshaler
+	// Equal returns wether the two addresses are equal.
+	Equal(Address) bool
+	// Cmp compares the byte representation of two addresses. For `a.Cmp(b)`
+	// returns -1 if a < b, 0 if a == b, 1 if a > b.
+	Cmp(Address) int
 }
 
 // Addresses is a helper type for encoding and decoding address slices in

--- a/wire/cache_internal_test.go
+++ b/wire/cache_internal_test.go
@@ -16,6 +16,7 @@ package wire
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +37,7 @@ func TestCache(t *testing.T) {
 
 	ping0 := newEnvelope(NewPingMsg())
 	pong := newEnvelope(NewPongMsg())
+	time.Sleep(1 * time.Millisecond) // Sleep to ensure unique timestamps.
 	ping1 := newEnvelope(NewPingMsg())
 	ping2 := newEnvelope(NewPingMsg())
 	// we want to uniquely identify messages by their timestamp

--- a/wire/cache_internal_test.go
+++ b/wire/cache_internal_test.go
@@ -15,36 +15,29 @@
 package wire
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	wtest "perun.network/go-perun/wallet/test"
-	"polycry.pt/poly-go/test"
 )
 
-// newRandomEnvelope - copy from wire/test for internal tests.
-func newRandomEnvelope(rng *rand.Rand, m Msg) *Envelope {
+func newEnvelope(m Msg) *Envelope {
 	return &Envelope{
-		Sender:    wtest.NewRandomAddress(rng),
-		Recipient: wtest.NewRandomAddress(rng),
+		Sender:    nil,
+		Recipient: nil,
 		Msg:       m,
 	}
 }
 
 func TestCache(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
-	rng := test.Prng(t)
-
 	c := MakeCache()
 	require.Zero(c.Size())
 
-	ping0 := newRandomEnvelope(rng, NewPingMsg())
-	pong := newRandomEnvelope(rng, NewPongMsg())
-	ping1 := newRandomEnvelope(rng, NewPingMsg())
-	ping2 := newRandomEnvelope(rng, NewPingMsg())
+	ping0 := newEnvelope(NewPingMsg())
+	pong := newEnvelope(NewPongMsg())
+	ping1 := newEnvelope(NewPingMsg())
+	ping2 := newEnvelope(NewPingMsg())
 	// we want to uniquely identify messages by their timestamp
 	require.False(ping0.Msg.(*PingMsg).Created.Equal(ping1.Msg.(*PingMsg).Created))
 

--- a/wire/generate.go
+++ b/wire/generate.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package wire
 
-import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
-)
+// NewAddressFunc is an address generator function.
+type NewAddressFunc = func() Address
+
+var newAddress NewAddressFunc
+
+// SetNewAddressFunc sets the address generator function.
+func SetNewAddressFunc(f NewAddressFunc) {
+	newAddress = f
+}
+
+// NewAddress returns a new address.
+func NewAddress() Address {
+	return newAddress()
+}

--- a/wire/init_test.go
+++ b/wire/init_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package wire_test
 
 import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
+	_ "perun.network/go-perun/backend/sim/wire" // backend init
 )

--- a/wire/net/endpoint.go
+++ b/wire/net/endpoint.go
@@ -16,6 +16,7 @@ package net
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -104,5 +105,5 @@ func newEndpoint(addr wire.Address, conn Conn) *Endpoint {
 
 // String returns the Endpoint's address string.
 func (p *Endpoint) String() string {
-	return p.Address.String()
+	return fmt.Sprint(p.Address)
 }

--- a/wire/net/endpoint_internal_test.go
+++ b/wire/net/endpoint_internal_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	_ "perun.network/go-perun/backend/sim" // backend init
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	perunio "perun.network/go-perun/wire/perunio/serializer"
 	wiretest "perun.network/go-perun/wire/test"
@@ -98,12 +97,12 @@ type client struct {
 // makeClient creates a simulated test client.
 func makeClient(conn Conn, rng *rand.Rand, dialer Dialer) *client {
 	receiver := wire.NewReceiver()
-	registry := NewEndpointRegistry(wallettest.NewRandomAccount(rng), func(wire.Address) wire.Consumer {
+	registry := NewEndpointRegistry(wiretest.NewRandomAccount(rng), func(wire.Address) wire.Consumer {
 		return receiver
 	}, dialer, perunio.Serializer())
 
 	return &client{
-		endpoint: registry.addEndpoint(wallettest.NewRandomAddress(rng), conn, true),
+		endpoint: registry.addEndpoint(wiretest.NewRandomAddress(rng), conn, true),
 		Registry: registry,
 		Receiver: receiver,
 	}
@@ -202,7 +201,7 @@ func TestEndpoint_ClosedByRecvLoopOnConnClose(t *testing.T) {
 	eofReceived := make(chan struct{})
 
 	rng := test.Prng(t)
-	addr := wallettest.NewRandomAddress(rng)
+	addr := wiretest.NewRandomAddress(rng)
 	conn0, conn1 := newPipeConnPair()
 	peer := newEndpoint(addr, conn0)
 

--- a/wire/net/endpoint_registry_external_test.go
+++ b/wire/net/endpoint_registry_external_test.go
@@ -22,11 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	"perun.network/go-perun/wire/net"
 	nettest "perun.network/go-perun/wire/net/test"
 	perunio "perun.network/go-perun/wire/perunio/serializer"
+	wiretest "perun.network/go-perun/wire/test"
 	ctxtest "polycry.pt/poly-go/context/test"
 	"polycry.pt/poly-go/sync"
 	"polycry.pt/poly-go/test"
@@ -42,8 +42,8 @@ func TestEndpointRegistry_Get_Pair(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 	rng := test.Prng(t)
 	var hub nettest.ConnHub
-	dialerID := wallettest.NewRandomAccount(rng)
-	listenerID := wallettest.NewRandomAccount(rng)
+	dialerID := wiretest.NewRandomAccount(rng)
+	listenerID := wiretest.NewRandomAccount(rng)
 	dialerReg := net.NewEndpointRegistry(dialerID, nilConsumer, hub.NewNetDialer(), perunio.Serializer())
 	listenerReg := net.NewEndpointRegistry(listenerID, nilConsumer, nil, perunio.Serializer())
 	listener := hub.NewNetListener(listenerID.Address())
@@ -82,8 +82,8 @@ func TestEndpointRegistry_Get_Multiple(t *testing.T) {
 	assert := assert.New(t)
 	rng := test.Prng(t)
 	var hub nettest.ConnHub
-	dialerID := wallettest.NewRandomAccount(rng)
-	listenerID := wallettest.NewRandomAccount(rng)
+	dialerID := wiretest.NewRandomAccount(rng)
+	listenerID := wiretest.NewRandomAccount(rng)
 	dialer := hub.NewNetDialer()
 	logPeer := func(addr wire.Address) wire.Consumer {
 		t.Logf("subscribing %s\n", addr)

--- a/wire/net/exchange_addr_internal_test.go
+++ b/wire/net/exchange_addr_internal_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	wiretest "perun.network/go-perun/wire/test"
 	ctxtest "polycry.pt/poly-go/context/test"
@@ -32,7 +31,7 @@ func TestExchangeAddrs_ConnFail(t *testing.T) {
 	rng := test.Prng(t)
 	a, _ := newPipeConnPair()
 	a.Close()
-	addr, err := ExchangeAddrsPassive(context.Background(), wallettest.NewRandomAccount(rng), a)
+	addr, err := ExchangeAddrsPassive(context.Background(), wiretest.NewRandomAccount(rng), a)
 	assert.Nil(t, addr)
 	assert.Error(t, err)
 }
@@ -41,7 +40,7 @@ func TestExchangeAddrs_Success(t *testing.T) {
 	rng := test.Prng(t)
 	conn0, conn1 := newPipeConnPair()
 	defer conn0.Close()
-	account0, account1 := wallettest.NewRandomAccount(rng), wallettest.NewRandomAccount(rng)
+	account0, account1 := wiretest.NewRandomAccount(rng), wiretest.NewRandomAccount(rng)
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -67,7 +66,7 @@ func TestExchangeAddrs_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	ctxtest.AssertTerminates(t, 2*timeout, func() {
-		addr, err := ExchangeAddrsPassive(ctx, wallettest.NewRandomAccount(rng), a)
+		addr, err := ExchangeAddrsPassive(ctx, wiretest.NewRandomAccount(rng), a)
 		assert.Nil(t, addr)
 		assert.Error(t, err)
 	})
@@ -75,7 +74,7 @@ func TestExchangeAddrs_Timeout(t *testing.T) {
 
 func TestExchangeAddrs_BogusMsg(t *testing.T) {
 	rng := test.Prng(t)
-	acc := wallettest.NewRandomAccount(rng)
+	acc := wiretest.NewRandomAccount(rng)
 	conn := newMockConn()
 	conn.recvQueue <- wiretest.NewRandomEnvelope(rng, wire.NewPingMsg())
 	addr, err := ExchangeAddrsPassive(context.Background(), acc, conn)

--- a/wire/net/simple/dialer.go
+++ b/wire/net/simple/dialer.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
 	wirenet "perun.network/go-perun/wire/net"
 	pkgsync "polycry.pt/poly-go/sync"
@@ -30,10 +29,10 @@ import (
 // Dialer is a simple lookup-table based dialer that can dial known peers.
 // New peer addresses can be added via Register().
 type Dialer struct {
-	mutex   sync.RWMutex              // Protects peers.
-	peers   map[wallet.AddrKey]string // Known peer addresses.
-	dialer  net.Dialer                // Used to dial connections.
-	network string                    // The socket type.
+	mutex   sync.RWMutex            // Protects peers.
+	peers   map[wire.AddrKey]string // Known peer addresses.
+	dialer  net.Dialer              // Used to dial connections.
+	network string                  // The socket type.
 
 	pkgsync.Closer
 }
@@ -47,7 +46,7 @@ var _ wirenet.Dialer = (*Dialer)(nil)
 // `serializer` defines the message encoding.
 func NewNetDialer(network string, defaultTimeout time.Duration) *Dialer {
 	return &Dialer{
-		peers:   make(map[wallet.AddrKey]string),
+		peers:   make(map[wire.AddrKey]string),
 		dialer:  net.Dialer{Timeout: defaultTimeout},
 		network: network,
 	}
@@ -63,7 +62,7 @@ func NewUnixDialer(defaultTimeout time.Duration) *Dialer {
 	return NewNetDialer("unix", defaultTimeout)
 }
 
-func (d *Dialer) host(key wallet.AddrKey) (string, bool) {
+func (d *Dialer) host(key wire.AddrKey) (string, bool) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
@@ -76,7 +75,7 @@ func (d *Dialer) Dial(ctx context.Context, addr wire.Address, ser wire.EnvelopeS
 	done := make(chan struct{})
 	defer close(done)
 
-	host, ok := d.host(wallet.Key(addr))
+	host, ok := d.host(wire.Key(addr))
 	if !ok {
 		return nil, errors.New("peer not found")
 	}
@@ -106,5 +105,5 @@ func (d *Dialer) Register(addr wire.Address, address string) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 
-	d.peers[wallet.Key(addr)] = address
+	d.peers[wire.Key(addr)] = address
 }

--- a/wire/net/simple/dialer_internal_test.go
+++ b/wire/net/simple/dialer_internal_test.go
@@ -22,10 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	simwallet "perun.network/go-perun/backend/sim/wallet"
-	"perun.network/go-perun/wallet"
 	"perun.network/go-perun/wire"
 	perunio "perun.network/go-perun/wire/perunio/serializer"
+	wiretest "perun.network/go-perun/wire/test"
 	ctxtest "polycry.pt/poly-go/context/test"
 	"polycry.pt/poly-go/test"
 )
@@ -42,8 +41,8 @@ func TestNewUnixDialer(t *testing.T) {
 
 func TestDialer_Register(t *testing.T) {
 	rng := test.Prng(t)
-	addr := simwallet.NewRandomAddress(rng)
-	key := wallet.Key(addr)
+	addr := wiretest.NewRandomAddress(rng)
+	key := wire.Key(addr)
 	d := NewTCPDialer(0)
 
 	_, ok := d.host(key)
@@ -60,7 +59,7 @@ func TestDialer_Dial(t *testing.T) {
 	timeout := 100 * time.Millisecond
 	rng := test.Prng(t)
 	lhost := "127.0.0.1:7357"
-	laddr := simwallet.NewRandomAddress(rng)
+	laddr := wiretest.NewRandomAddress(rng)
 
 	l, err := NewTCPListener(lhost)
 	require.NoError(t, err)
@@ -69,7 +68,7 @@ func TestDialer_Dial(t *testing.T) {
 	ser := perunio.Serializer()
 	d := NewTCPDialer(timeout)
 	d.Register(laddr, lhost)
-	daddr := simwallet.NewRandomAddress(rng)
+	daddr := wiretest.NewRandomAddress(rng)
 	defer d.Close()
 
 	t.Run("happy", func(t *testing.T) {
@@ -113,7 +112,7 @@ func TestDialer_Dial(t *testing.T) {
 	})
 
 	t.Run("unknown host", func(t *testing.T) {
-		noHostAddr := simwallet.NewRandomAddress(rng)
+		noHostAddr := wiretest.NewRandomAddress(rng)
 		d.Register(noHostAddr, "no such host")
 
 		ctxtest.AssertTerminates(t, timeout, func() {
@@ -125,7 +124,7 @@ func TestDialer_Dial(t *testing.T) {
 
 	t.Run("unknown address", func(t *testing.T) {
 		ctxtest.AssertTerminates(t, timeout, func() {
-			unkownAddr := simwallet.NewRandomAddress(rng)
+			unkownAddr := wiretest.NewRandomAddress(rng)
 			conn, err := d.Dial(context.Background(), unkownAddr, ser)
 			assert.Error(t, err)
 			assert.Nil(t, conn)

--- a/wire/net/simple/init_test.go
+++ b/wire/net/simple/init_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package simple_test
 
 import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
+	_ "perun.network/go-perun/backend/sim/wire" // backend init
 )

--- a/wire/net/test/connhub_internal_test.go
+++ b/wire/net/test/connhub_internal_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "perun.network/go-perun/backend/sim" // backend init
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	perunio "perun.network/go-perun/wire/perunio/serializer"
 	wiretest "perun.network/go-perun/wire/test"
@@ -38,7 +37,7 @@ func TestConnHub_Create(t *testing.T) {
 		assert := assert.New(t)
 
 		var c ConnHub
-		addr := wallettest.NewRandomAddress(rng)
+		addr := wiretest.NewRandomAddress(rng)
 		d, l := c.NewNetDialer(), c.NewNetListener(addr)
 		assert.NotNil(d)
 		assert.NotNil(l)
@@ -71,7 +70,7 @@ func TestConnHub_Create(t *testing.T) {
 		assert := assert.New(t)
 
 		var c ConnHub
-		addr := wallettest.NewRandomAddress(rng)
+		addr := wiretest.NewRandomAddress(rng)
 
 		l := c.NewNetListener(addr)
 		assert.NotNil(l)
@@ -86,7 +85,7 @@ func TestConnHub_Create(t *testing.T) {
 
 		d := c.NewNetDialer()
 		ctxtest.AssertTerminates(t, timeout, func() {
-			conn, err := d.Dial(context.Background(), wallettest.NewRandomAddress(rng), ser)
+			conn, err := d.Dial(context.Background(), wiretest.NewRandomAddress(rng), ser)
 			assert.Nil(conn)
 			assert.Error(err)
 		})
@@ -97,7 +96,7 @@ func TestConnHub_Create(t *testing.T) {
 
 		var c ConnHub
 		c.Close()
-		addr := wallettest.NewRandomAddress(rng)
+		addr := wiretest.NewRandomAddress(rng)
 
 		assert.Panics(func() { c.NewNetDialer() })
 		assert.Panics(func() { c.NewNetListener(addr) })
@@ -110,7 +109,7 @@ func TestConnHub_Close(t *testing.T) {
 		assert := assert.New(t)
 
 		var c ConnHub
-		l := c.NewNetListener(wallettest.NewRandomAddress(rng))
+		l := c.NewNetListener(wiretest.NewRandomAddress(rng))
 		assert.NoError(c.Close())
 		assert.True(l.IsClosed())
 	})
@@ -119,10 +118,10 @@ func TestConnHub_Close(t *testing.T) {
 		assert := assert.New(t)
 
 		var c ConnHub
-		l := c.NewNetListener(wallettest.NewRandomAddress(rng))
+		l := c.NewNetListener(wiretest.NewRandomAddress(rng))
 		l2 := NewNetListener()
 		l2.Close()
-		err := c.insert(wallettest.NewRandomAccount(rng).Address(), l2)
+		err := c.insert(wiretest.NewRandomAccount(rng).Address(), l2)
 		assert.NoError(err)
 		assert.Error(c.Close())
 		assert.True(l.IsClosed())

--- a/wire/net/test/dialer_internal_test.go
+++ b/wire/net/test/dialer_internal_test.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"perun.network/go-perun/wallet/test"
 	perunio "perun.network/go-perun/wire/perunio/serializer"
+	"perun.network/go-perun/wire/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/wire/net/test/listenermap_internal_test.go
+++ b/wire/net/test/listenermap_internal_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"perun.network/go-perun/wallet/test"
+	"perun.network/go-perun/wire/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 

--- a/wire/perunio/test/serializertest.go
+++ b/wire/perunio/test/serializertest.go
@@ -34,8 +34,8 @@ func GenericSerializerTest(t *testing.T, serializers ...perunio.Serializer) {
 
 // genericDecodeEncodeTest tests whether encoding and then decoding
 // serializer values results in the original values.
+//nolint:thelper // The linter thinks this is a helper, but it isn't.
 func genericDecodeEncodeTest(t *testing.T, serializers ...perunio.Serializer) {
-	t.Helper()
 	for i, v := range serializers {
 		r, w := io.Pipe()
 		br := iotest.OneByteReader(r)
@@ -58,9 +58,10 @@ func genericDecodeEncodeTest(t *testing.T, serializers ...perunio.Serializer) {
 	}
 }
 
-// GenericBrokenPipeTest tests that encoding and decoding on broken streams fails.
+// GenericBrokenPipeTest tests that encoding and decoding on broken streams
+// fails.
+//nolint:thelper // The linter thinks this is a helper, but it isn't.
 func GenericBrokenPipeTest(t *testing.T, serializers ...perunio.Serializer) {
-	t.Helper()
 	for i, v := range serializers {
 		r, w := io.Pipe()
 		_ = w.Close()

--- a/wire/protobuf/init_test.go
+++ b/wire/protobuf/init_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
+// Copyright 2022 - See NOTICE file for copyright holders.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sim
+package protobuf_test
 
 import (
-	_ "perun.network/go-perun/backend/sim/channel" // backend init
-	_ "perun.network/go-perun/backend/sim/wallet"  // backend init
-	_ "perun.network/go-perun/backend/sim/wire"    // backend init
+	_ "perun.network/go-perun/backend/sim/wire" // backend init
 )

--- a/wire/protobuf/proposalmsgs.go
+++ b/wire/protobuf/proposalmsgs.go
@@ -121,7 +121,7 @@ func toWalletAddr(protoAddr []byte) (wallet.Address, error) {
 func toWalletAddrs(protoAddrs [][]byte) ([]wallet.Address, error) {
 	addrs := make([]wallet.Address, len(protoAddrs))
 	for i := range protoAddrs {
-		addrs[i] = wire.NewAddress()
+		addrs[i] = wallet.NewAddress()
 		err := addrs[i].UnmarshalBinary(protoAddrs[i])
 		if err != nil {
 			return nil, errors.WithMessagef(err, "%d'th address", i)

--- a/wire/protobuf/test/serializertest.go
+++ b/wire/protobuf/test/serializertest.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	"perun.network/go-perun/wire/protobuf"
+	"perun.network/go-perun/wire/test"
 	pkgtest "polycry.pt/poly-go/test"
 )
 
@@ -47,7 +47,7 @@ func MsgSerializerTest(t *testing.T, msg wire.Msg) {
 
 func newEnvelope(rng *rand.Rand) *wire.Envelope {
 	return &wire.Envelope{
-		Sender:    wallettest.NewRandomAddress(rng),
-		Recipient: wallettest.NewRandomAddress(rng),
+		Sender:    test.NewRandomAddress(rng),
+		Recipient: test.NewRandomAddress(rng),
 	}
 }

--- a/wire/receiver_internal_test.go
+++ b/wire/receiver_internal_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	ctxtest "polycry.pt/poly-go/context/test"
-	"polycry.pt/poly-go/test"
 )
 
 // timeout controls how long to wait until we decide that something will never
@@ -39,7 +38,7 @@ func TestReceiver_Close(t *testing.T) {
 
 func TestReceiver_Next(t *testing.T) {
 	t.Parallel()
-	e := newRandomEnvelope(test.Prng(t), NewPingMsg())
+	e := newEnvelope(NewPingMsg())
 
 	t.Run("Happy case", func(t *testing.T) {
 		t.Parallel()

--- a/wire/relay_internal_test.go
+++ b/wire/relay_internal_test.go
@@ -23,10 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	wallettest "perun.network/go-perun/wallet/test"
 	ctxtest "polycry.pt/poly-go/context/test"
 	"polycry.pt/poly-go/sync"
-	"polycry.pt/poly-go/test"
 )
 
 func TestProducer(t *testing.T) {
@@ -47,18 +45,6 @@ func TestProducer(t *testing.T) {
 	assert.Equal(t, len(p.consumers), 2)
 	assert.False(t, p.isEmpty())
 	assert.Panics(t, func() { p.delete(r0) })
-}
-
-func TestProducer_produce_closed(t *testing.T) {
-	var missed *Envelope
-	p := NewRelay()
-	p.SetDefaultMsgHandler(func(e *Envelope) { missed = e })
-	assert.NoError(t, p.Close())
-	rng := test.Prng(t)
-	a := wallettest.NewRandomAddress(rng)
-	b := wallettest.NewRandomAddress(rng)
-	p.Put(&Envelope{a, b, NewPingMsg()})
-	assert.Nil(t, missed, "produce() on closed producer shouldn't do anything")
 }
 
 func TestProducer_SetDefaultMsgHandler(t *testing.T) {
@@ -128,10 +114,9 @@ func TestProducer_caching(t *testing.T) {
 	ctx := context.Background()
 	prod.Cache(&isPing)
 
-	rng := test.Prng(t)
-	ping0 := newRandomEnvelope(rng, NewPingMsg())
-	pong1 := newRandomEnvelope(rng, NewPongMsg())
-	pong2 := newRandomEnvelope(rng, NewPongMsg())
+	ping0 := newEnvelope(NewPingMsg())
+	pong1 := newEnvelope(NewPongMsg())
+	pong2 := newEnvelope(NewPongMsg())
 
 	prod.Put(ping0)
 	assert.Equal(1, prod.cache.Size())

--- a/wire/test/address.go
+++ b/wire/test/address.go
@@ -1,0 +1,68 @@
+// Copyright 2022 - See NOTICE file for copyright holders.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/perunio"
+	pkgtest "polycry.pt/poly-go/test"
+)
+
+// TestAddressImplementation runs a test suite designed to test the general
+// functionality of an address implementation.
+//nolint:revive // The function name `test.Test...` stutters, but it is OK in this special case.
+func TestAddressImplementation(t *testing.T, newAddress wire.NewAddressFunc, newRandomAddress NewRandomAddressFunc) {
+	rng := pkgtest.Prng(t)
+	require, assert := require.New(t), assert.New(t)
+	addr := newRandomAddress(rng)
+
+	// Test Address.MarshalBinary and UnmarshalBinary.
+	data, err := addr.MarshalBinary()
+	assert.NoError(err)
+	assert.NoError(addr.UnmarshalBinary(data), "Byte deserialization of address should work")
+
+	// Test Address.Equals.
+	null := newAddress()
+	assert.False(addr.Equal(null), "Expected inequality of zero, nonzero address")
+	assert.True(null.Equal(null), "Expected equality of zero address to itself") //nolint:gocritic
+
+	// Test Address.Cmp.
+	assert.Positive(addr.Cmp(null), "Expected addr > zero")
+	assert.Zero(null.Cmp(null), "Expected zero = zero") //nolint:gocritic
+	assert.Negative(null.Cmp(addr), "Expected null < addr")
+
+	// Test Address.Bytes.
+	addrBytes, err := addr.MarshalBinary()
+	assert.NoError(err, "Marshaling address should not error")
+	nullBytes, err := null.MarshalBinary()
+	assert.NoError(err, "Marshaling zero address should not error")
+	assert.False(bytes.Equal(addrBytes, nullBytes), "Expected inequality of byte representations of nonzero and zero address")
+
+	// a.Equal(Decode(Encode(a)))
+	t.Run("Serialize Equal Test", func(t *testing.T) {
+		buff := new(bytes.Buffer)
+		require.NoError(perunio.Encode(buff, addr))
+		addr2 := newAddress()
+		err := perunio.Decode(buff, addr2)
+		require.NoError(err)
+
+		assert.True(addr.Equal(addr2))
+	})
+}

--- a/wire/test/bustest.go
+++ b/wire/test/bustest.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 	"polycry.pt/poly-go/test"
 )
@@ -56,7 +55,7 @@ func GenericBusTest(t *testing.T,
 	clients := make([]Client, numClients)
 	for i := range clients {
 		clients[i].r = wire.NewRelay()
-		clients[i].id = wallettest.NewRandomAccount(rng)
+		clients[i].id = NewRandomAccount(rng)
 		clients[i].pub, clients[i].sub = busAssigner(clients[i].id)
 	}
 

--- a/wire/test/msgstest.go
+++ b/wire/test/msgstest.go
@@ -18,7 +18,6 @@ import (
 	"math/rand"
 	"testing"
 
-	wallettest "perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 
 	pkgtest "polycry.pt/poly-go/test"
@@ -41,7 +40,7 @@ func AuthMsgsSerializationTest(t *testing.T, serializerTest func(t *testing.T, m
 	t.Helper()
 
 	rng := pkgtest.Prng(t)
-	serializerTest(t, wire.NewAuthResponseMsg(wallettest.NewRandomAccount(rng)))
+	serializerTest(t, wire.NewAuthResponseMsg(NewRandomAccount(rng)))
 }
 
 // newRandomASCIIString returns a random ascii string of length between minLen and

--- a/wire/test/randomizer.go
+++ b/wire/test/randomizer.go
@@ -17,22 +17,46 @@ package test
 import (
 	"math/rand"
 
-	"perun.network/go-perun/wallet/test"
 	"perun.network/go-perun/wire"
 )
 
-// NewRandomAddress returns a new random peer address. Currently still a stub
-// until the crypto for peer addresses is decided.
+type (
+	// NewRandomAddressFunc is a address randomizer function.
+	NewRandomAddressFunc = func(*rand.Rand) wire.Address
+	// NewRandomAccountFunc is a account randomizer function.
+	NewRandomAccountFunc = func(*rand.Rand) wire.Account
+)
+
+var (
+	newRandomAddress NewRandomAddressFunc
+	newRandomAccount NewRandomAccountFunc
+)
+
+// SetNewRandomAddress sets the address randomizer function.
+func SetNewRandomAddress(f NewRandomAddressFunc) {
+	newRandomAddress = f
+}
+
+// SetNewRandomAccount sets the account randomizer function.
+func SetNewRandomAccount(f NewRandomAccountFunc) {
+	newRandomAccount = f
+}
+
+// NewRandomAddress returns a new random address.
 func NewRandomAddress(rng *rand.Rand) wire.Address {
-	return test.NewRandomAddress(rng)
+	return newRandomAddress(rng)
+}
+
+// NewRandomAccount returns a new random account.
+func NewRandomAccount(rng *rand.Rand) wire.Account {
+	return newRandomAccount(rng)
 }
 
 // NewRandomAddresses returns a slice of random peer addresses.
 func NewRandomAddresses(rng *rand.Rand, n int) []wire.Address {
-	walletAddresses := test.NewRandomAddresses(rng, n)
-	addresses := make([]wire.Address, len(walletAddresses))
-	for i, x := range walletAddresses {
-		addresses[i] = x
+	addresses := make([]wire.Address, n)
+	for i := range addresses {
+		addresses[i] = NewRandomAddress(rng)
 	}
 	return addresses
 }
@@ -41,8 +65,8 @@ func NewRandomAddresses(rng *rand.Rand, n int) []wire.Address {
 // recipient generated using randomness from rng.
 func NewRandomEnvelope(rng *rand.Rand, m wire.Msg) *wire.Envelope {
 	return &wire.Envelope{
-		Sender:    test.NewRandomAddress(rng),
-		Recipient: test.NewRandomAddress(rng),
+		Sender:    NewRandomAddress(rng),
+		Recipient: NewRandomAddress(rng),
 		Msg:       m,
 	}
 }


### PR DESCRIPTION
Closes #234.

In general, this PR will ensure that `wire.Address` and `wallet.Address` are distinct. Before, `wire.Address` was a synonym for `wallet.Address`, which caused some problems, in particular, mixing up `wire.Address` and `wallet.Address` and adding functionality to `wallet.Address` which was specific to the use case of `wire.Address` (concretely, the `Cmp` function).

In this PR we assign both their own type.