### PR TITLE
Remove settle secondary

### DIFF
--- a/channel/adjudicator.go
+++ b/channel/adjudicator.go
@@ -103,17 +103,11 @@ type (
 
 	// An AdjudicatorReq collects all necessary information to make calls to the
 	// adjudicator.
-	//
-	// If the Secondary flag is set to true, it is assumed that this is an
-	// on-chain request that is executed by the other channel participants as well
-	// and the Adjudicator backend may run an optimized on-chain transaction
-	// protocol, possibly saving unnecessary double sending of transactions.
 	AdjudicatorReq struct {
-		Params    *Params
-		Acc       wallet.Account
-		Tx        Transaction
-		Idx       Index // Always the own index
-		Secondary bool  // Optimized secondary call protocol
+		Params *Params
+		Acc    wallet.Account
+		Tx     Transaction
+		Idx    Index // Always the own index
 	}
 
 	// SignedState represents a signed channel state including parameters.

--- a/channel/machine.go
+++ b/channel/machine.go
@@ -249,9 +249,6 @@ func (m *machine) CurrentTX() Transaction {
 // AdjudicatorReq returns the adjudicator request for the current channel
 // transaction (the current state together with all participants' signatures on
 // it).
-//
-// The Secondary flag is left as false. Set it manually after creating the
-// request if you want to use optimized sencondary adjudication logic.
 func (m *machine) AdjudicatorReq() AdjudicatorReq {
 	return AdjudicatorReq{
 		Params: &m.params,

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -303,7 +303,7 @@ func (c *Channel) Settle(ctx context.Context) (err error) {
 	return nil
 }
 
-func (c *Channel) withdraw(ctx context.Context, secondary bool) error {
+func (c *Channel) withdraw(ctx context.Context) error {
 	switch {
 	case c.IsLedgerChannel():
 		subStates, err := c.subChannelStateMap()
@@ -311,7 +311,6 @@ func (c *Channel) withdraw(ctx context.Context, secondary bool) error {
 			return errors.WithMessage(err, "creating sub-channel state map")
 		}
 		req := c.machine.AdjudicatorReq()
-		req.Secondary = secondary
 		if err := c.adjudicator.Withdraw(ctx, req, subStates); err != nil {
 			return errors.WithMessage(err, "calling Withdraw")
 		}

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -242,7 +242,7 @@ func (c *Channel) ForceUpdate(ctx context.Context, updater func(*channel.State))
 // to be mined.
 // Returns ChainNotReachableError if the connection to the blockchain network
 // fails when sending a transaction to / reading from the blockchain.
-func (c *Channel) Settle(ctx context.Context, secondary bool) (err error) {
+func (c *Channel) Settle(ctx context.Context) (err error) {
 	if !c.State().IsFinal {
 		err := c.ensureRegistered(ctx)
 		if err != nil {
@@ -268,7 +268,7 @@ func (c *Channel) Settle(ctx context.Context, secondary bool) (err error) {
 	}
 
 	// Withdraw.
-	err = c.withdraw(ctx, secondary)
+	err = c.withdraw(ctx)
 	if err != nil {
 		return
 	}

--- a/client/test/bob.go
+++ b/client/test/bob.go
@@ -57,7 +57,7 @@ func (r *Bob) exec(_cfg ExecConfig, ch *paymentChannel, propHandler *acceptNextP
 	ch.sendFinal()
 
 	// 4th Settle channel
-	ch.settleSecondary()
+	ch.settle()
 
 	// 4th final stage
 	r.waitStage()

--- a/client/test/channel.go
+++ b/client/test/channel.go
@@ -168,18 +168,10 @@ func (ch *paymentChannel) recvFinal() {
 }
 
 func (ch *paymentChannel) settle() {
-	ch.settleImpl(false)
-}
-
-func (ch *paymentChannel) settleSecondary() {
-	ch.settleImpl(true)
-}
-
-func (ch *paymentChannel) settleImpl(secondary bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), ch.r.timeout)
 	defer cancel()
 
-	ch.r.RequireNoError(ch.Settle(ctx, secondary))
+	ch.r.RequireNoError(ch.Settle(ctx))
 	ch.assertBals(ch.State())
 
 	if ch.IsSubChannel() {

--- a/client/test/fund.go
+++ b/client/test/fund.go
@@ -129,7 +129,7 @@ func runFredFridaTest(
 	require.IsType(t, &client.ChannelFundingError{}, err)
 	require.NotNil(t, chFrida)
 	// Frida settles the channel.
-	require.NoError(t, chFrida.Settle(ctx, false))
+	require.NoError(t, chFrida.Settle(ctx))
 
 	// Fred gets the channel and settles it afterwards.
 	chFred := <-chsFred
@@ -141,7 +141,7 @@ func runFredFridaTest(
 		require.NoError(t, ctx.Err())
 	}
 	// Fred settles the channel.
-	require.NoError(t, chFred.Settle(ctx, false))
+	require.NoError(t, chFred.Settle(ctx))
 
 	// Test the final balances.
 	balancesAfter := channel.Balances{

--- a/client/test/multiledger_dispute.go
+++ b/client/test/multiledger_dispute.go
@@ -127,9 +127,9 @@ func TestMultiLedgerDispute(
 	require.NoError(err)
 
 	// Settle.
-	err = chAliceBob.Settle(ctx, false)
+	err = chAliceBob.Settle(ctx)
 	require.NoError(err)
-	err = chBobAlice.Settle(ctx, false)
+	err = chBobAlice.Settle(ctx)
 	require.NoError(err)
 
 	// Close the channels.

--- a/client/test/multiledger_happy.go
+++ b/client/test/multiledger_happy.go
@@ -90,8 +90,8 @@ func TestMultiLedgerHappy(ctx context.Context, t *testing.T, mlt MultiLedgerSetu
 	require.NoError(err)
 
 	// Close channel.
-	err = chAliceBob.Settle(ctx, false)
+	err = chAliceBob.Settle(ctx)
 	require.NoError(err)
-	err = chBobAlice.Settle(ctx, false)
+	err = chBobAlice.Settle(ctx)
 	require.NoError(err)
 }

--- a/client/test/persistence.go
+++ b/client/test/persistence.go
@@ -125,7 +125,7 @@ func (r *Petra) Execute(cfg ExecConfig) {
 	// 6. Finalize restored channel
 	ch.recvFinal()
 
-	ch.settleSecondary()
+	ch.settle()
 
 	r.RequireNoError(r.Close())
 }

--- a/client/test/progression.go
+++ b/client/test/progression.go
@@ -116,7 +116,7 @@ func (r *Paul) exec(_cfg ExecConfig, ch *paymentChannel) {
 	r.waitStage()
 
 	// withdraw
-	r.RequireNoError(ch.Settle(ctx, false))
+	r.RequireNoError(ch.Settle(ctx))
 }
 
 // ----------------- BEGIN PAULA -----------------
@@ -181,5 +181,5 @@ func (r *Paula) exec(_cfg ExecConfig, ch *paymentChannel, _ *acceptNextPropHandl
 	r.RequireNoErrorf(e.Timeout().Wait(ctx), "waiting for progression timeout")
 
 	// withdraw
-	r.RequireNoError(ch.Settle(ctx, true))
+	r.RequireNoError(ch.Settle(ctx))
 }

--- a/client/test/subchannel.go
+++ b/client/test/subchannel.go
@@ -209,7 +209,7 @@ func (r *Tim) exec(_cfg ExecConfig, ledgerChannel *paymentChannel, propHandler *
 
 	finalizeAndSettle := func(ch *paymentChannel) {
 		ch.recvFinal()
-		ch.settleSecondary()
+		ch.settle()
 	}
 
 	for i, ch := range subChannels {

--- a/client/test/virtualchannel.go
+++ b/client/test/virtualchannel.go
@@ -56,7 +56,7 @@ func TestVirtualChannelOptimistic( //nolint:revive // test.Test... stutters but 
 	success.Add(len(chs))
 	for _, ch := range chs {
 		go func(ch *client.Channel) {
-			err := ch.Settle(ctx, false)
+			err := ch.Settle(ctx)
 			if err != nil {
 				vct.errs <- err
 				return
@@ -102,7 +102,7 @@ func TestVirtualChannelDispute( //nolint:revive // test.Test... stutters but OK 
 
 	// Settle the channels in a random order.
 	for _, i := range rand.Perm(len(chs)) {
-		err := chs[i].Settle(ctx, false)
+		err := chs[i].Settle(ctx)
 		assert.NoErrorf(err, "settle channel: %d", i)
 	}
 

--- a/watcher/local/watcher.go
+++ b/watcher/local/watcher.go
@@ -439,9 +439,8 @@ func makeSignedState(params *channel.Params, tx channel.Transaction) channel.Sig
 
 func makeAdjudicatorReq(params *channel.Params, tx channel.Transaction) channel.AdjudicatorReq {
 	return channel.AdjudicatorReq{
-		Params:    params,
-		Tx:        tx,
-		Secondary: false,
+		Params: params,
+		Tx:     tx,
 	}
 }
 


### PR DESCRIPTION
This PR removes the settle secondary logic. It was not well documented and rarely used, and lead to confusion. We can still implement the same functionality on the application level if necessary.

Closes #81 