### PR TITLE
Handle update locked

### DIFF
--- a/client/update.go
+++ b/client/update.go
@@ -113,7 +113,7 @@ func (r *UpdateResponder) Accept(ctx context.Context) error {
 		return errors.New("context must not be nil")
 	}
 	if !r.called.TrySet() {
-		log.Panic("multiple calls on channel update responder")
+		return fmt.Errorf("multiple calls on channel update responder")
 	}
 
 	return r.channel.handleUpdateAcc(ctx, r.pidx, r.req)
@@ -125,7 +125,7 @@ func (r *UpdateResponder) Reject(ctx context.Context, reason string) error {
 		return errors.New("context must not be nil")
 	}
 	if !r.called.TrySet() {
-		log.Panic("multiple calls on channel update responder")
+		return fmt.Errorf("multiple calls on channel update responder")
 	}
 
 	return r.channel.handleUpdateRej(ctx, r.pidx, r.req, reason)

--- a/client/update_internal_test.go
+++ b/client/update_internal_test.go
@@ -18,21 +18,8 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestUpdateResponder_Accept_NilArgs(t *testing.T) {
-	err := new(UpdateResponder).Accept(nil) //nolint:staticcheck
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context")
-}
-
-func TestUpdateResponder_Reject_NilArgs(t *testing.T) {
-	err := new(UpdateResponder).Reject(nil, "reason") //nolint:staticcheck
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context")
-}
 
 func TestRequestTimedOutError(t *testing.T) {
 	err := newRequestTimedOutError("", "")


### PR DESCRIPTION
Our update handling logic allowed potentially left the channel state machine unlocked if not used correctly. Correct usage was neither documented, nor enforced. This PR proposes an update handling mechanism where the channel machine is only unlocked once the update handler is done.

Closes #270 