### PR TITLE
Fix local watcher deadlock

### DIFF
--- a/client/test/role.go
+++ b/client/test/role.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
+	"os"
+	"runtime/pprof"
 	"sync"
 	"testing"
 	"time"
@@ -137,6 +139,7 @@ func ExecuteTwoPartyTest(ctx context.Context, t *testing.T, role [2]Executer, cf
 	select {
 	case <-wg.WaitCh():
 	case <-ctx.Done():
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1) //nolint:errcheck
 		t.Fatal(ctx.Err())
 	case err := <-role[0].Errors():
 		t.Fatal(err)


### PR DESCRIPTION
In rare occasions, the local watcher was running into a deadlock when stopping and handling an event at the same time.