### PR TITLE
Allow retry Channel.ForceUpdate

### DIFF
--- a/channel/machine.go
+++ b/channel/machine.go
@@ -401,7 +401,7 @@ func (m *machine) SetRegistered() error {
 // the given state.
 func (m *machine) SetProgressing(state *State) error {
 	if !inPhase(m.phase, []Phase{Registered, Progressing, Progressed}) {
-		return m.phaseErrorf(m.selfTransition(), "can only progress when registered or progressed")
+		return m.phaseErrorf(m.selfTransition(), "can only progress after registration")
 	}
 	m.setStaging(Progressing, state)
 	return nil

--- a/channel/machine.go
+++ b/channel/machine.go
@@ -400,7 +400,7 @@ func (m *machine) SetRegistered() error {
 // SetProgressing sets the machine phase to Progressing and the staging state to
 // the given state.
 func (m *machine) SetProgressing(state *State) error {
-	if !inPhase(m.phase, []Phase{Registered, Progressed}) {
+	if !inPhase(m.phase, []Phase{Registered, Progressing, Progressed}) {
 		return m.phaseErrorf(m.selfTransition(), "can only progress when registered or progressed")
 	}
 	m.setStaging(Progressing, state)

--- a/client/adjudicate.go
+++ b/client/adjudicate.go
@@ -447,7 +447,9 @@ func (c *Channel) subChannelStateMap() (states channel.StateMap, err error) {
 // ensureRegistered ensures that the channel is registered.
 func (c *Channel) ensureRegistered(ctx context.Context) error {
 	phase := c.Phase()
-	if phase == channel.Registered || phase == channel.Progressed {
+	if phase == channel.Registered ||
+		phase == channel.Progressing ||
+		phase == channel.Progressed {
 		return nil
 	}
 


### PR DESCRIPTION
If a ForceUpdate fails, the channel may remain in state `Progressing`.
With this change we allow for retrying from this phase.