### PR TITLE
wire.proto: use absolute module path

### DIFF
--- a/wire/protobuf/wire.proto
+++ b/wire/protobuf/wire.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package perunwire;
 
-option go_package = "../protobuf";
+option go_package = "perun.network/go-perun/wire/protobuf";
 
 // Envelope encapsulates a message with the routing information. That is the
 // the sender and the intended receiver.


### PR DESCRIPTION
This allows including `wire.proto` in other projects and generates the correct include paths in .proto modules including it.

Signed-off-by: Steffen Rattay <steffen@perun.network>