### PR TITLE
#395_Fix_Falling_Unit_Tests

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@
 | Steffen Rattay  | [@rmbrt](https://github.com/rmbrt) | rmbrt |
 | Ilja von Hoessle  | [@iljabvh](https://github.com/iljabvh) | iljabvh |
 | Jens Winkle       | [@DragonDev1906](https://github.com/DragonDev1906) | jens#4601 |
+| Minh Huy Tran      | [@NhoxxKienn](https://github.com/NhoxxKienn) | NhoxxKienn |
 
 ## Emeritus Maintainers
 

--- a/NOTICE
+++ b/NOTICE
@@ -42,6 +42,7 @@ PolyCrypt GmbH
     Oliver Tale-Yazdi <oliver@perun.network>
     Ilja von Hoessle <ilja@perun.network>
     Jens Winkle <jens@perun.network>
+    Minh Huy Tran <huy@perun.network>
     
 Robert Bosch GmbH
     Manoranjith <ponraj.manoranjitha@in.bosch.com>

--- a/channel/test/app_randomizer.go
+++ b/channel/test/app_randomizer.go
@@ -27,7 +27,7 @@ type AppRandomizer interface {
 	NewRandomData(*rand.Rand) channel.Data
 }
 
-var appRandomizer AppRandomizer = &MockAppRandomizer{}
+var appRandomizer AppRandomizer = NewMockAppRandomizer()
 
 // isAppRandomizerSet tracks whether the AppRandomizer was already set
 // with `SetAppRandomizer`.

--- a/channel/test/app_randomizer_internal_test.go
+++ b/channel/test/app_randomizer_internal_test.go
@@ -29,13 +29,13 @@ func TestAppRandomizerSet(t *testing.T) {
 	assert.False(t, isAppRandomizerSet, "isAppRandomizerSet should be defaulted to false")
 
 	old := appRandomizer
-	assert.NotPanics(t, func() { SetAppRandomizer(&MockAppRandomizer{}) }, "first SetAppRandomizer() should work")
+	assert.NotPanics(t, func() { SetAppRandomizer(NewMockAppRandomizer()) }, "first SetAppRandomizer() should work")
 	assert.True(t, isAppRandomizerSet, "isAppRandomizerSet should be true")
 	assert.NotNil(t, appRandomizer, "appRandomizer should not be nil")
 	assert.False(t, old == appRandomizer, "appRandomizer should have changed")
 
 	old = appRandomizer
-	assert.Panics(t, func() { SetAppRandomizer(&MockAppRandomizer{}) }, "second SetAppRandomizer() should panic")
+	assert.Panics(t, func() { SetAppRandomizer(NewMockAppRandomizer()) }, "second SetAppRandomizer() should panic")
 	assert.True(t, isAppRandomizerSet, "isAppRandomizerSet should be true")
 	assert.NotNil(t, appRandomizer, "appRandomizer should not be nil")
 	assert.True(t, old == appRandomizer, "appRandomizer should not have changed")

--- a/channel/test/mock_app_randomizer.go
+++ b/channel/test/mock_app_randomizer.go
@@ -17,11 +17,19 @@ package test
 import (
 	"math/rand"
 
+	"github.com/google/uuid"
 	"perun.network/go-perun/channel"
 )
 
 // MockAppRandomizer implements the AppRandomizer interface.
-type MockAppRandomizer struct{}
+type MockAppRandomizer struct {
+	id uuid.UUID // Unique identifier for each instance
+}
+
+// NewMockAppRandomizer creates a new instance of MockAppRandomizer with a unique identifier.
+func NewMockAppRandomizer() *MockAppRandomizer {
+	return &MockAppRandomizer{id: uuid.New()}
+}
 
 // NewRandomApp creates a new MockApp with a random address.
 func (MockAppRandomizer) NewRandomApp(rng *rand.Rand) channel.App {
@@ -31,4 +39,9 @@ func (MockAppRandomizer) NewRandomApp(rng *rand.Rand) channel.App {
 // NewRandomData creates a new MockOp with a random operation.
 func (MockAppRandomizer) NewRandomData(rng *rand.Rand) channel.Data {
 	return channel.NewMockOp(channel.MockOp(rng.Uint64()))
+}
+
+// Equal returns false for any comparison, ensuring two MockAppRandomizers are always considered different.
+func (m *MockAppRandomizer) Equal(other *MockAppRandomizer) bool {
+	return m.id != other.id
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=

--- a/wire/net/simple/init.go
+++ b/wire/net/simple/init.go
@@ -14,10 +14,21 @@
 
 package simple
 
-import "perun.network/go-perun/wire"
+import (
+	"math/rand"
+
+	"perun.network/go-perun/wire"
+	"perun.network/go-perun/wire/test"
+)
 
 func init() {
 	wire.SetNewAddressFunc(func() wire.Address {
 		return NewAddress("")
+	})
+	test.SetNewRandomAddress(func(rng *rand.Rand) wire.Address {
+		return NewRandomAddress(rng)
+	})
+	test.SetNewRandomAccount(func(rng *rand.Rand) wire.Account {
+		return NewRandomAccount(rng)
 	})
 }


### PR DESCRIPTION
## Description
This PR serves to fix the #395 issue of failing unit tests. 

### App Randomizer Internal Test 
Location: `channel/test/app_randomizer_internal_test.go`

Cause: The issue stems from the lack of Comparator (`Equal`) for MockAppRandomizer. This leads to the test not recognizing that the default appRandomizer has already been set in the internal test.

Solution: Add an identifier to the MockAppRandomizer to compare the old and new appRandomizer.

### Dialer Internal Test
Location: (`wire/net/simple/dialer_internal_test.go`)

Cause: Like @RmbRT has pointed out, there is a race between the init of `wire/simple` and `backend/sim/wire`, which set the RandomAddress and RandomAccount functions to be used in the internal tests.

Solution: Add the initialization of `NewRandomAddress` and `NewRandomAccount` to use the implementation from the `wire/simple`.

Alternative: Remove `init()` of `wire/simple` and only use the init of `backend/sim/wire`. This also results in passing internal tests but might cause issues for packages using `wire/simple` (need further investigation).
