### PR TITLE
fix(wire/net): remove test backend signature from authMsg of exchange address protocol

### DIFF
--- a/wire/account.go
+++ b/wire/account.go
@@ -40,8 +40,6 @@ type Account interface {
 	Sign(msg []byte) ([]byte, error)
 }
 
-const testBackendID = 0
-
 var _ Msg = (*AuthResponseMsg)(nil)
 
 // AuthResponseMsg is the response message in the peer authentication protocol.

--- a/wire/account.go
+++ b/wire/account.go
@@ -84,7 +84,7 @@ func (m *AuthResponseMsg) Decode(r io.Reader) (err error) {
 }
 
 // NewAuthResponseMsg creates an authentication response message.
-func NewAuthResponseMsg(acc map[wallet.BackendID]Account) (Msg, error) {
+func NewAuthResponseMsg(acc map[wallet.BackendID]Account, backendID wallet.BackendID) (Msg, error) {
 	addressMap := make(map[wallet.BackendID]Address)
 	for id, a := range acc {
 		addressMap[id] = a.Address()
@@ -98,7 +98,7 @@ func NewAuthResponseMsg(acc map[wallet.BackendID]Account) (Msg, error) {
 		}
 		addressBytes = append(addressBytes, addrBytes...)
 	}
-	signature, err := acc[testBackendID].Sign(addressBytes)
+	signature, err := acc[backendID].Sign(addressBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign address: %w", err)
 	}

--- a/wire/net/simple/address.go
+++ b/wire/net/simple/address.go
@@ -28,9 +28,6 @@ import (
 	"perun.network/go-perun/wire"
 )
 
-// testBackendID is the identifier for the simulated Backend.
-const testBackendID = 0
-
 // Address is a wire address.
 type Address struct {
 	Name      string
@@ -208,7 +205,7 @@ func NewRandomAddress(rng *rand.Rand) *Address {
 }
 
 // NewRandomAddresses returns a new random peer address.
-func NewRandomAddresses(rng *rand.Rand) map[wallet.BackendID]wire.Address {
+func NewRandomAddresses(rng *rand.Rand, backendID []wallet.BackendID) map[wallet.BackendID]wire.Address {
 	const addrLen = 32
 	l := rng.Intn(addrLen)
 	d := make([]byte, l)
@@ -216,10 +213,14 @@ func NewRandomAddresses(rng *rand.Rand) map[wallet.BackendID]wire.Address {
 		panic(err)
 	}
 
-	a := Address{
-		Name: string(d),
+	addresses := make(map[wallet.BackendID]wire.Address)
+	for _, id := range backendID {
+		a := Address{
+			Name: string(d),
+		}
+		addresses[id] = &a
 	}
-	return map[wallet.BackendID]wire.Address{testBackendID: &a}
+	return addresses
 }
 
 // Verify verifies a message signature.

--- a/wire/net/simple/dialer_internal_test.go
+++ b/wire/net/simple/dialer_internal_test.go
@@ -139,7 +139,7 @@ func TestDialer_Dial(t *testing.T) {
 	})
 
 	t.Run("unknown host", func(t *testing.T) {
-		noHostAddr := NewRandomAddresses(rng)
+		noHostAddr := NewRandomAddresses(rng, []wallet.BackendID{wiretest.TestBackendID})
 		d.Register(noHostAddr, "no such host")
 
 		ctxtest.AssertTerminates(t, timeout, func() {
@@ -151,7 +151,7 @@ func TestDialer_Dial(t *testing.T) {
 
 	t.Run("unknown address", func(t *testing.T) {
 		ctxtest.AssertTerminates(t, timeout, func() {
-			unkownAddr := NewRandomAddresses(rng)
+			unkownAddr := NewRandomAddresses(rng, []wallet.BackendID{wiretest.TestBackendID})
 			conn, err := d.Dial(context.Background(), unkownAddr, ser)
 			assert.Error(t, err)
 			assert.Nil(t, conn)

--- a/wire/net/simple/simple_exchange_addr_test.go
+++ b/wire/net/simple/simple_exchange_addr_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"perun.network/go-perun/channel"
+	"perun.network/go-perun/wallet"
 
 	"github.com/stretchr/testify/assert"
 
@@ -107,8 +108,8 @@ func newPipeConnPair() (a wirenet.Conn, b wirenet.Conn) {
 // recipient generated using randomness from rng.
 func newRandomEnvelope(rng *rand.Rand, m wire.Msg) *wire.Envelope {
 	return &wire.Envelope{
-		Sender:    NewRandomAddresses(rng),
-		Recipient: NewRandomAddresses(rng),
+		Sender:    NewRandomAddresses(rng, []wallet.BackendID{wiretest.TestBackendID}),
+		Recipient: NewRandomAddresses(rng, []wallet.BackendID{wiretest.TestBackendID}),
 		Msg:       m,
 	}
 }

--- a/wire/test/msgstest.go
+++ b/wire/test/msgstest.go
@@ -40,7 +40,7 @@ func AuthMsgsSerializationTest(t *testing.T, serializerTest func(t *testing.T, m
 	t.Helper()
 
 	rng := pkgtest.Prng(t)
-	testMsg, err := wire.NewAuthResponseMsg(NewRandomAccountMap(rng, TestBackendID))
+	testMsg, err := wire.NewAuthResponseMsg(NewRandomAccountMap(rng, TestBackendID), TestBackendID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR fix the bug #421 by removing the hard-coded test-backend signature from AuthMsg and required the user to sign all of the address map using all of there backends.

## Location
`wire/net` package 

## Disclaimer
This implementation increase the number of authentication msgs by the number of backends (log(n)) and could cause performance issues with a large number of backends.


Signed-off-by: Minh Huy Tran <huy@perun.network>