### PR TITLE
Minor Release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] Narvi - 2025-10-02
+Extended the testing framework with more robust tests for payment and virtual channels.  
+Added documentation for cross-chain backend integration and backend ID mapping.
+
+
+### Added
+
+* Documentation section describing supported backends and their IDs.
+
+### Changed
+
+* Extended Perun testing framework with improved payment and virtual channel tests. [#423]
+
+[#423]: https://github.com/hyperledger-labs/go-perun/pull/423
+
 ## [0.14.0] Narvi - 2025-07-29 [:boom:]
 Added [Libp2p](https://libp2p.io/) wire for go-perun. This enables seamless and secure P2P connection between clients.
 

--- a/README.md
+++ b/README.md
@@ -70,25 +70,26 @@ The following features are planned for future releases:
 
 ### Backends
 
- _go-perun_ supports multiple **blockchain backends**. A backend is automatically initialized when its top-level package `backend/<name>` is imported.
-| ID  | Backend    | Status                  | Repository                                                                           |
-| --- | ---------- | ----------------------- | ------------------------------------------------------------------------------------ |
-| 0   | SimBackend | 🧪 Testing only          | Built-in (`backend/sim`) – represents an ideal blockchain backend for simulation     |
-| 1   | Ethereum   | ✅ Cross-chain supported | [perun-eth-backend](https://github.com/perun-network/perun-eth-backend/)             |
-| 2   | Stellar    | ✅ Cross-chain supported | [perun-stellar-backend](https://github.com/perun-network/perun-stellar-backend)      |
-| 3   | Nervos     | 🛠 In development        | [perun-ckb-backend](https://github.com/perun-network/perun-ckb-backend)              |
-| 4   | Polkadot   | 🛠 In development        | [perun-polkadot-backend](https://github.com/perun-network/perun-polkadot-backend)    |
-| 5   | Dfinity    | 🛠 In development        | [perun-icp-backend](https://github.com/perun-network/perun-icp-backend)              |
-| 6   | Solana     | 🛠 In development        | [perun-solana-backend](https://github.com/perun-network/perun-solana-backend)        |
-| -   | Cosmos     | ❌ Not supported         | [perun-cosmwasm-backend](https://github.com/hyperledger-labs/perun-cosmwasm-backend) |
-| -   | Cardano    | ❌ Not supported         | [perun-cardano-backend](https://github.com/perun-network/perun-cardano-backend)      |
-| -   | Fabric     | ❌ Not supported         | [perun-fabric](https://github.com/perun-network/perun-fabric)                        |
+ _go-perun_ supports multiple **blockchain backends**. A backend is automatically initialized when its top-level package `backend/<name>` is imported.#### Backend Map
+
+| ID  | Backend    | Payment Channel Status | Cross-Chain Status | Repository                                                                           |
+| --- | ---------- | ---------------------- | ------------------ | ------------------------------------------------------------------------------------ |
+| 0   | SimBackend | 🧪 Testing only         | 🧪 Testing only     | Built-in (`backend/sim`) – represents an ideal blockchain backend for simulation     |
+| 1   | Ethereum   | ✅ Supported            | ✅ Supported        | [perun-eth-backend](https://github.com/perun-network/perun-eth-backend/)             |
+| 2   | Stellar    | ✅ Supported            | ✅ Supported        | [perun-stellar-backend](https://github.com/perun-network/perun-stellar-backend)      |
+| 3   | Nervos     | ✅ Supported            | 🚧 In development   | [perun-ckb-backend](https://github.com/perun-network/perun-ckb-backend)              |
+| 4   | Polkadot   | ✅ Supported            | 🚧 In development   | [perun-polkadot-backend](https://github.com/perun-network/perun-polkadot-backend)    |
+| 5   | Dfinity    | ✅ Supported            | 🚧 In development   | [perun-icp-backend](https://github.com/perun-network/perun-icp-backend)              |
+| 6   | Solana     | 🚧 In development       | 🚧 In development   | [perun-solana-backend](https://github.com/perun-network/perun-solana-backend)        |
+| -   | Cosmos     | ✅ Supported            | 🟡 Single-chain     | [perun-cosmwasm-backend](https://github.com/hyperledger-labs/perun-cosmwasm-backend) |
+| -   | Cardano    | ✅ Supported            | 🟡 Single-chain     | [perun-cardano-backend](https://github.com/perun-network/perun-cardano-backend)      |
+| -   | Fabric     | ✅ Supported            | 🟡 Single-chain     | [perun-fabric](https://github.com/perun-network/perun-fabric)                        |
 
 #### Legend
-- ✅ **Cross-chain supported** – stable, production-ready backends.  
-- 🛠 **In development / upgrade** – experimental or actively being updated.  
-- ❌ **Not cross-chain supported** – backend is chain-specific, not compatible for cross-chain mode.  
-- 🧪 **Testing only** – simulation backend, no real blockchain.
+- ✅ **Supported** – stable and available.  
+- 🚧 **In development** – actively worked on, not fully stable.  
+- 🟡 **Single-chain** – supports only local (non-cross-chain) payment/state channels.  
+- 🧪 **Testing only** – simulation backend, no real blockchain. 
 
 **Logging and networking** capabilities can also be injected by the user.
 A default [logrus](https://github.com/sirupsen/logrus) implementation of the `log.Logger` interface can be set using `log/logrus.Set`.

--- a/README.md
+++ b/README.md
@@ -70,16 +70,25 @@ The following features are planned for future releases:
 
 ### Backends
 
-There are multiple **blockchain backends** available. A backend is automatically initialized when its top-level package `backend/<name>` is imported.
-- **Ethereum.** The Ethereum backend is available at [perun-eth-backend](https://github.com/perun-network/perun-eth-backend/).
-- **Polkadot.** The Polkadot backend is available at [perun-polkadot-backend](https://github.com/perun-network/perun-polkadot-backend).
-- **Cosmos.** The Cosmos backend is available at [perun-cosmwasm-backend](https://github.com/hyperledger-labs/perun-cosmwasm-backend).
-- **Cardano.** The Cardano backend is available at [perun-cardano-backend](https://github.com/perun-network/perun-cardano-backend).
-- **NERVOS.** The NERVOS backend is available at [perun-ckb-backend](https://github.com/perun-network/perun-ckb-backend).
-- **Dfinity.** The Dfinity Internet Computer backend is available at [perun-icp-backend](https://github.com/perun-network/perun-icp-backend).
-- **Stellar.** The Stellar backend is available at [perun-stellar-backend](https://github.com/perun-network/perun-stellar-backend).
-- **Fabric.** The Hyperledger Fabric backend is available at [perun-fabric](https://github.com/perun-network/perun-fabric).
-- **SimBackend.** The SimBackend represents an ideal blockchain backend (`backend/sim`) implementation that can be used for testing.
+ _go-perun_ supports multiple **blockchain backends**. A backend is automatically initialized when its top-level package `backend/<name>` is imported.
+| ID  | Backend    | Status                  | Repository                                                                           |
+| --- | ---------- | ----------------------- | ------------------------------------------------------------------------------------ |
+| 0   | SimBackend | 🧪 Testing only          | Built-in (`backend/sim`) – represents an ideal blockchain backend for simulation     |
+| 1   | Ethereum   | ✅ Cross-chain supported | [perun-eth-backend](https://github.com/perun-network/perun-eth-backend/)             |
+| 2   | Stellar    | ✅ Cross-chain supported | [perun-stellar-backend](https://github.com/perun-network/perun-stellar-backend)      |
+| 3   | Nervos     | 🛠 In development        | [perun-ckb-backend](https://github.com/perun-network/perun-ckb-backend)              |
+| 4   | Polkadot   | 🛠 In development        | [perun-polkadot-backend](https://github.com/perun-network/perun-polkadot-backend)    |
+| 5   | Dfinity    | 🛠 In development        | [perun-icp-backend](https://github.com/perun-network/perun-icp-backend)              |
+| 6   | Solana     | 🛠 In development        | [perun-solana-backend](https://github.com/perun-network/perun-solana-backend)        |
+| -   | Cosmos     | ❌ Not supported         | [perun-cosmwasm-backend](https://github.com/hyperledger-labs/perun-cosmwasm-backend) |
+| -   | Cardano    | ❌ Not supported         | [perun-cardano-backend](https://github.com/perun-network/perun-cardano-backend)      |
+| -   | Fabric     | ❌ Not supported         | [perun-fabric](https://github.com/perun-network/perun-fabric)                        |
+
+#### Legend
+- ✅ **Cross-chain supported** – stable, production-ready backends.  
+- 🛠 **In development / upgrade** – experimental or actively being updated.  
+- ❌ **Not cross-chain supported** – backend is chain-specific, not compatible for cross-chain mode.  
+- 🧪 **Testing only** – simulation backend, no real blockchain.
 
 **Logging and networking** capabilities can also be injected by the user.
 A default [logrus](https://github.com/sirupsen/logrus) implementation of the `log.Logger` interface can be set using `log/logrus.Set`.


### PR DESCRIPTION
This PR updates the `CHANGELOG` with features for the minor release `v0.14.1`, which includes:

* PR [423](https://github.com/hyperledger-labs/go-perun/pull/423): Extend go-perun testing framework.
* Updates `README.md` to document the supported Backends and their IDs for cross-chain functionality #427 . 
